### PR TITLE
Not every static array is stored on the stack

### DIFF
--- a/public/content/en/basics.md
+++ b/public/content/en/basics.md
@@ -501,7 +501,8 @@ a failed range check yields a `RangeError` which aborts the application. The bra
 can disable this with the compiler flag `-boundschecks=off` to squeeze
 the last cycles out of their binary.
 
-**static** arrays are stored on the stack and have a fixed,
+**static** arrays are stored on the stack if defined inside a function
+or in static memory otherwise.  They have a fixed,
 compile-time known length. An static array's type includes
 the fixed size:
 


### PR DESCRIPTION
Demo:

msl@james:~/d$ cat statarray.d 
#!/usr/bin/rdmd

import std.stdio;

int[8] sa;

void main() {
    int p;
    int[8] ia;
    int[8] ja = new int[8];
    int q;
    writeln(&p);
    writeln(&ia[0]);
    writeln(&ja[0]);
    writeln(&q);
    writeln(&sa[0]);
}

msl@james:~/d$ ./statarray.d 
7FFDD88048B8
7FFDD88048C8
7FFDD88048E8
7FFDD8804908
7F4EBDAAC700
msl@james:~/d$