### PR TITLE
use tabs instead of spaces for html scope example

### DIFF
--- a/public/content/en/gems.md
+++ b/public/content/en/gems.md
@@ -75,15 +75,15 @@ void main()
     scope(exit) writeln("</html>");
 
     {
-        writeln("  <head>");
-        scope(exit) writeln("  </head>");
-        "    <title>%s</title>".writefln("Hello");
+        writeln("\t<head>");
+        scope(exit) writeln("\t</head>");
+        "\t<title>%s</title>".writefln("Hello");
     }
 
-    writeln("  <body>");
-    scope(exit) writeln("  </body>");
+    writeln("\t<body>");
+    scope(exit) writeln("\t</body>");
 
-    writeln("    <h1>Hello World!</h1>");
+    writeln("\t\t<h1>Hello World!</h1>");
 }
 
 # Range algorithms


### PR DESCRIPTION
I would even say that we should get rid of them entirely as this complicates the example unnecessarily.