### PR TITLE
use wordcount example with lowerCase words

### DIFF
--- a/public/content/en/basics.md
+++ b/public/content/en/basics.md
@@ -1031,6 +1031,7 @@ int[string] wordCount(string text)
     // The function splitter lazily splits the
     // input into a range
     import std.algorithm.iteration: splitter;
+    import std.string: toLower;
 
     // Indexed by words and returning the count
     int[string] words;
@@ -1043,7 +1044,7 @@ int[string] wordCount(string text)
     // The parameter we pass behind ! is an
     // expression that marks the condition when
     // to split text
-    foreach(word; splitter!pred(text)) {
+    foreach(word; splitter!pred(text.toLower())) {
         // Increment word count if word
         // has been found.
         // Integers are by default 0.


### PR DESCRIPTION
As said it was a bit frustrating to see only 1 matches - an alternative would be rewrite the dummy text so that at least one word occurs twice.

```
Word counts: ["which":1, "systems":1, "of":1, "machine":1, "and":1, "":2, "code":1, "*native*":1, "you":1, "expressive":1, "powerful":1, "language":1, "tour":1, "compiles":1, "directly":1, "give":1, "will":1, "this":2, "an":1, "overview":1, "programming":1, "to":1, "efficient":1]
```