### PR TITLE
Implement #57.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ script:
   - if [[ "${DC}" == "dmd" ]]; then  dub test --compiler=${DC};            fi
   # Compiler to static binary with gdc
   - if [[ "${DC}" == "ldc2" ]]; then  dub build -c static --compiler=${DC}; fi
-
-after_success:
   - if [[ "${DC}" == "ldc2" ]]; then docker build -t stonemaster/dlang-tour . ; fi
+  - if [[ "${DC}" == "ldc2" ]]; then docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -ti stonemaster/dlang-tour --sanitycheck ; fi
+
+before_deploy:
   - if [[ "${DC}" == "ldc2" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi
   - if [[ "${DC}" == "ldc2" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then docker push stonemaster/dlang-tour       ; fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,13 @@ online (the Run button is not visible on that tour
 page) mark the source code with a 2nd level title
 `{SourceCode:disabled}` instead of just `{SourceCode}`.
 
+If source code doesn't compile from the start and the user is
+supposed to complete the example code, mark the source code
+section title with `{SourceCode:incomplete}`. A sanity
+check is implemented which automatically checks source code
+examples for validity and those source code examples
+are just ignored.
+
 ### Source Code formatting
 
 * Source code examples should be indented with 4 spaces.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY public /public
 COPY docker/docker.start.sh /docker.start.sh
 RUN chmod +x /docker.start.sh
 
-CMD [ "/docker.start.sh" ]
+ENTRYPOINT [ "/docker.start.sh" ]

--- a/docker/docker.start.sh
+++ b/docker/docker.start.sh
@@ -9,4 +9,4 @@ cat /config.yml.tmpl | \
   sed "s/%EXEC_DOCKER_MAX_OUTPUT_SIZE%/${EXEC_DOCKER_MAX_OUTPUT_SIZE:-4096}/g" \
   > /config.yml
 
-exec /dlang-tour
+exec /dlang-tour $*

--- a/public/content/en/basics.md
+++ b/public/content/en/basics.md
@@ -501,7 +501,7 @@ the example application successfully run:
   conveniently returns a string using `printf`-like syntax:
   `format("MyInt = %d", myInt)`.
 
-## {SourceCode}
+## {SourceCode:incomplete}
 
 struct Vector3 {
     double x;
@@ -621,7 +621,7 @@ that shifts the characters in the alphabet using a certain index.
 The to-be-encrypted text just contains characters in the range `a-z`
 which should make things easier.
 
-## {SourceCode}
+## {SourceCode:incomplete}
 
 import std.stdio;
 
@@ -984,7 +984,7 @@ that returns numbers of the
 [Fibonacci sequence](https://en.wikipedia.org/wiki/Fibonacci_number).
 Don't fool yourself into deleting the `assert`ions!
 
-## {SourceCode}
+## {SourceCode:incomplete}
 
 import std.stdio;
 

--- a/public/content/en/gems.md
+++ b/public/content/en/gems.md
@@ -554,7 +554,7 @@ state during its whole lifetime:
 
 - [Contract programming in D](https://dlang.org/spec/contracts.html)
 
-## {SourceCode}
+## {SourceCode:incomplete}
 
 // Very simple Date type with a lot of
 // flaws. Hint: don't use it!
@@ -870,7 +870,7 @@ sections.
 - [DDoc design](https://dlang.org/spec/ddoc.html)
 - [Phobos standard library documentation](https://dlang.org/phobos)
 
-## {SourceCode}
+## {SourceCode:incomplete}
 
 /**
   Calculates the square root of a number.

--- a/source/app.d
+++ b/source/app.d
@@ -50,11 +50,60 @@ private IExecProvider createExecProvider(Config config,
 	return execProvider;
 }
 
+/++
+	Checks all source code example that are fetched from
+	$(D contentProvider). If a source code examples doesn't
+	compile an exception is thrown.
++/
+private void doSanityCheck(ContentProvider contentProvider, IExecProvider execProvider)
+{
+	import std.exception: enforce;
+
+	auto content = contentProvider.getContent();
+	foreach (section; content) {
+		if (section.sourceCode.empty) {
+			logInfo("[%s] Sanity check: Ignoring source code for section '%s' because it is empty.",
+					section.language, section.title);
+			continue;
+		}
+
+		if (!section.sourceCodeEnabled) {
+			logInfo("[%s] Sanity check: Ignoring source code for section '%s' because it is disabled.",
+					section.language, section.title);
+			continue;
+		}
+
+		if (section.sourceCodeIncomplete) {
+			logInfo("[%s] Sanity check: Ignoring source code for section '%s' because it is incomplete.",
+					section.language, section.title);
+			continue;
+		}
+
+		logInfo("[%s] Doing sanity check for section '%s'...",
+				section.language, section.title);
+		auto result = execProvider.compileAndExecute(section.sourceCode);
+		enforce(result.success,
+			"[%s] Sanity check: Source code for section '%s' doesn't compile!".format(section.language, section.title));
+	}
+}
+
 shared static this()
 {
 	string configFile = "config.yml";
 	readOption("c|config", &configFile, "Configuration file");
+	bool sanityCheck = false;
+	readOption("sanitycheck", &sanityCheck,
+		"Runs sanity check before starting that checks whether all source code examples actually compile; doesn't start the service");
 	auto config = new Config(configFile);
+
+	auto contentProvider = new ContentProvider(config.publicDir ~ "/content");
+	auto execProvider = createExecProvider(config, contentProvider);
+
+	if (sanityCheck) {
+		doSanityCheck(contentProvider, execProvider);
+		import std.c.stdlib: exit;
+		exit(0);
+	}
 
 	logInfo("Starting Dlang-tour on %s, port %d", config.bindAddresses, config.port);
 	logInfo("Google Analytics ID: %s", config.googleAnalyticsId);
@@ -63,9 +112,6 @@ shared static this()
 	settings.port = config.port;
 	settings.bindAddresses = config.bindAddresses;
 	settings.useCompressionIfPossible = true;
-
-	auto contentProvider = new ContentProvider(config.publicDir ~ "/content");
-	auto execProvider = createExecProvider(config, contentProvider);
 
 	auto urlRouter = new URLRouter;
 	auto fsettings = new HTTPFileServerSettings;


### PR DESCRIPTION
Sanity-checking can be done at startup of tour using the --sanitycheck flag.
All source code examples not markes as incomplete (title `{SourceCode:incomplete}`)
are checked for validity.

Also added travis CI so that is done before the final Docker image
is pushed.