### PR TITLE
Fix mobile menu

### DIFF
--- a/public/static/css/common.css
+++ b/public/static/css/common.css
@@ -33,7 +33,7 @@ body {
     #title {
         margin-right: 0em;
     }
-    #top .logo > a {
+    body #top .logo > a {
         margin-left: -4em;
     }
 }

--- a/public/static/css/menu.css
+++ b/public/static/css/menu.css
@@ -438,7 +438,8 @@ the home page, intro pitch and your-code-here layed out vertically */
         font-size: 2em;
         height: 100%;
         line-height: 1;
-        padding: 0.15em 1em;
+        margin-top: 0.2em;
+        margin-right: 0.75em;
     }
     #top a.hamburger span
     {
@@ -446,7 +447,9 @@ the home page, intro pitch and your-code-here layed out vertically */
     }
     #top a.hamburger::after
     {
-        content: "\f0c9"; /* bars */
-        font-family: FontAwesome;
+        /*content: "\f0c9"; [> bars <]*/
+        /*font-family: FontAwesome;*/
+        font-family: 'Glyphicons Halflings';
+        content: "\e236";
     }
 }


### PR DESCRIPTION
Apparently `common.css` is loaded before `menu.css`, hence the overwrite didn't work anymore.

Also I realized that FontAwesome is installed by default on my system. As Bootstrap's glypicons are already used, this swaps to use them instead. On the long term though, I recommend to use FontAwesome.
