### PR TITLE
Remove page background

### DIFF
--- a/public/static/css/tour.css
+++ b/public/static/css/tour.css
@@ -1,17 +1,10 @@
 #program-output {
 	font-family: monospace;
 	border: none;
-	background-color: #efefef;
 }
 
 #tour-content {
 	font-size: 16px;
-}
-
-@media only screen and (min-width: 66.01em) {
-    #tour-content {
-    	background-color: #efefef;
-    }
 }
 
 #tour-content h1 {


### PR DESCRIPTION
Fixes #206 - I believe with a white background the text is a lot easier to read. All major sites still use white ;-)

before:

![image](https://cloud.githubusercontent.com/assets/4370550/15939469/0fde3c24-2e78-11e6-9259-d5871a6dadaf.png)

after:

![image](https://cloud.githubusercontent.com/assets/4370550/15939422/ebc87b7e-2e77-11e6-9957-7e11a5ceda82.png)
