### PR TITLE
use ng-cloak to prevent inital page flows

### DIFF
--- a/public/static/css/common.css
+++ b/public/static/css/common.css
@@ -47,3 +47,6 @@ body {
 #github_avatar {
     float: right;
 }
+.ng-cloak {
+    display: none !important;
+}

--- a/views/base.dt
+++ b/views/base.dt
@@ -20,7 +20,7 @@ head
 		ga('create', '#{googleAnalyticsId}', 'auto');
 		ga('send', 'pageview');
 
-body(ng-app="DlangTourApp")
+body(ng-app="DlangTourApp", class="ng-cloak")
 	#top
 		.helper
 			.helper.expand-container.active


### PR DESCRIPTION
ng-cloak is a common practice to avoid visual glipses during the initial page load.
At the moment Angular triggers a couple of reflows when loading the source content.

However I am not sure about this.
Ideally we don't need it, because this means that the page won't work anymore without JavaScript.
In our current concept this could be tackled by directly filling the source box within the Vibed template.