### PR TITLE
Allow swiping on mobile devices - fixes #198

### DIFF
--- a/public/static/js/swipe.js
+++ b/public/static/js/swipe.js
@@ -1,0 +1,39 @@
+// adapted from http://stackoverflow.com/questions/15084675/how-to-implement-swipe-gestures-for-mobile-devices
+function detectswipe(el,func) {
+  swipe_det = new Object();
+  swipe_det.sX = 0; swipe_det.sY = 0; swipe_det.eX = 0; swipe_det.eY = 0;
+  var min_x = 30;  //min x swipe for horizontal swipe
+  var max_x = 30;  //max x difference for vertical swipe
+  var min_y = 50;  //min y swipe for vertical swipe
+  var max_y = 60;  //max y difference for horizontal swipe
+  var direc = "";
+  el.addEventListener('touchstart',function(e){
+    var t = e.touches[0];
+    swipe_det.sX = t.screenX;
+    swipe_det.sY = t.screenY;
+  },false);
+  el.addEventListener('touchmove',function(e){
+    e.preventDefault();
+    var t = e.touches[0];
+    swipe_det.eX = t.screenX;
+    swipe_det.eY = t.screenY;
+  },false);
+  el.addEventListener('touchend',function(e){
+    //horizontal detection
+    if ((((swipe_det.eX - min_x > swipe_det.sX) || (swipe_det.eX + min_x < swipe_det.sX)) && ((swipe_det.eY < swipe_det.sY + max_y) && (swipe_det.sY > swipe_det.eY - max_y) && (swipe_det.eX > 0)))) {
+      if(swipe_det.eX > swipe_det.sX) direc = "r";
+      else direc = "l";
+    }
+    //vertical detection
+    else if ((((swipe_det.eY - min_y > swipe_det.sY) || (swipe_det.eY + min_y < swipe_det.sY)) && ((swipe_det.eX < swipe_det.sX + max_x) && (swipe_det.sX > swipe_det.eX - max_x) && (swipe_det.eY > 0)))) {
+      if(swipe_det.eY > swipe_det.sY) direc = "d";
+      else direc = "u";
+    }
+
+    if (direc != "") {
+      if(typeof func == 'function') func(el,direc);
+    }
+    direc = "";
+    swipe_det.sX = 0; swipe_det.sY = 0; swipe_det.eX = 0; swipe_det.eY = 0;
+  },false);
+}

--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -106,22 +106,12 @@ dlangTourApp.controller('DlangTourAppCtrl', [ '$scope', '$http', 'hotkeys', func
 	hotkeys.add({
 		combo: 'left',
 		description: 'Go to previous section',
-		callback: function() {
-			$http.get('/previous-section/' + $scope.chapterId + '/' + $scope.section)
-				.success(function(data) {
-					window.location.href = data.location;
-				});
-		}
+		callback: prevPage
 	});
 	hotkeys.add({
 		combo: 'right',
 		description: 'Go to next section',
-		callback: function() {
-			$http.get('/next-section/' + $scope.chapterId + '/' + $scope.section)
-				.success(function(data) {
-					window.location.href = data.location;
-				});
-		}
+		callback: nextPage
 	});
 	hotkeys.add({
 		combo: 'ctrl+enter',
@@ -136,6 +126,30 @@ dlangTourApp.controller('DlangTourAppCtrl', [ '$scope', '$http', 'hotkeys', func
 		callback: function(e) {
 			$scope.reset();
 			e.preventDefault();
+		}
+	});
+
+	function prevPage()
+	{
+		$http.get('/previous-section/' + $scope.chapterId + '/' + $scope.section)
+		.success(function(data) {
+			window.location.href = data.location;
+		});
+	};
+
+	function nextPage()
+	{
+		$http.get('/next-section/' + $scope.chapterId + '/' + $scope.section)
+		.success(function(data) {
+			window.location.href = data.location;
+		});
+	}
+
+	detectswipe(document.getElementById('tour-content'), function(el, direction) {
+		if (direction == "r") {
+			prevPage();
+		} else if (direction == "l") {
+			nextPage();
 		}
 	});
 }]);

--- a/views/tour.dt
+++ b/views/tour.dt
@@ -2,6 +2,7 @@ extends base
 
 block head
 	script(src="/static/js/tour-controller.js")
+	script(src="/static/js/swipe.js")
 	link(rel="stylesheet", href="/static/lib/codemirror/lib/codemirror.min.css")
 	script(src="/static/lib/codemirror/lib/codemirror.min.js")
 	script(src="/static/lib/codemirror/mode/d/d.min.js")


### PR DESCRIPTION
Simple, light-weight swipe support. If this ever turns out, not to work that well, we can switch to full-blown solutions like:

- http://hammerjs.github.io/
- https://docs.angularjs.org/api/ngTouch