### PR TITLE
[Issue #235] Simplify welcome page four

### DIFF
--- a/public/content/en/basics.md
+++ b/public/content/en/basics.md
@@ -1527,3 +1527,23 @@ void main() {
     multipleNoise(dog, 5);
     multipleNoise(cat, 5);
 }
+
+# Further Reading
+
+Now that you've finished the basics, you can move on to some more advanced sections of this tour. Or, you can check out some of the following resources.
+
+* The [D Wiki](https://wiki.dlang.org/), which contains a lot of information and links
+* [Articles about D](http://dlang.org/articles.html)
+* [Books about D](https://wiki.dlang.org/Books), for an in-depth view
+
+### In-depth
+
+* Get familiar with the API of the standard library [Phobos](https://dlang.org/phobos)
+* Read the [language reference](https://dlang.org/spec/)
+* The [Forums](https://forum.dlang.org/) contain very active discussions
+* Browse the [Dub Repository](https://code.dlang.org), hosting an ever growing list of 3rd-party D programs and libraries.
+* Browse the source code on github ([dmd compiler](https://github.com/dlang/dmd), [Phobos standard library](https://github.com/dlang/phobos), [druntime](https://github.com/dlang/druntime))
+* Follow the [DStyle](http://dlang.org/dstyle.html)
+* See the D Language on [Rosetta code](http://rosettacode.org/wiki/Category:D)
+* Explore [awesome-d](https://github.com/zhaopuming/awesome-d/blob/master/README.md) - A curated list of awesome D frameworks, libraries and software
+* Get inspired by [Idioms for the D Programming Language](https://p0nce.github.io/d-idioms/)

--- a/public/content/en/welcome.md
+++ b/public/content/en/welcome.md
@@ -40,6 +40,11 @@ Each section comes with a source code example that can be modified and used
 to experiment with D's language features.
 Click the run button (or `Shift-enter`) to compile and run it.
 
+### Contributing
+
+This tour is [open source](https://github.com/stonemaster/dlang-tour/tree/master/public/content/en)
+and we are glad about pull requests making this tour even better.
+
 ## {SourceCode}
 
 import std.stdio;
@@ -110,16 +115,13 @@ usage.
 
 # Links & Documentation
 
-The best places to learn D are
+After you complete the tour, you can check out some of the following links for help or more information:
 
 * [Learning D as a beginner](http://ddili.org/ders/d.en/index.html)
 * [Learning D for experienced programmers](http://wiki.dlang.org/Coming_From) coming from other languages
-* The [D Wiki](https://wiki.dlang.org/), which contains a lot of information and links
 * [D Tutorials](https://wiki.dlang.org/Tutorials)
 * [Overview about D's unique features](http://dlang.org/overview.html)
 * [FAQ](http://dlang.org/faq.html)
-* [Articles about D](http://dlang.org/articles.html)
-* [Books about D](https://wiki.dlang.org/Books), for an in-depth view
 
 ### Help
 
@@ -127,22 +129,6 @@ The best places to learn D are
 * Get help at [D.learn](http://forum.dlang.org/group/learn)
 * Open an issue [at the D bugtracker](https://issues.dlang.org)
 
-### In-depth
-
-* Get familiar with the API of the standard library [Phobos](https://dlang.org/phobos)
-* Read the [language reference](https://dlang.org/spec/)
-* The [Forums](https://forum.dlang.org/) contain very active discussions
-* Browse the [Dub Repository](https://code.dlang.org), hosting an ever growing list of 3rd-party D programs and libraries.
-* Browse the source code on github ([dmd compiler](https://github.com/dlang/dmd), [Phobos standard library](https://github.com/dlang/phobos), [druntime](https://github.com/dlang/druntime))
-* Follow the [DStyle](http://dlang.org/dstyle.html)
-* See the D Language on [Rosetta code](http://rosettacode.org/wiki/Category:D)
-* Explore [awesome-d](https://github.com/zhaopuming/awesome-d/blob/master/README.md) - A curated list of awesome D frameworks, libraries and software
-* Get inspired by [Idioms for the D Programming Language](https://p0nce.github.io/d-idioms/)
-
-### Contributing
-
-This tour is [open source](https://github.com/stonemaster/dlang-tour/tree/master/public/content/en)
-and we are glad about pull requests making this tour even better.
 
 # Let's Go!
 


### PR DESCRIPTION
<img width="304" alt="screen shot 2016-06-10 at 2 55 58 pm" src="https://cloud.githubusercontent.com/assets/680068/15975448/7ace4468-2f1b-11e6-9cc4-3bc8c2197267.png">

Welcome page four has the biggest drop off of any page other than the home page. This should reduce the "too much information" feeling that some might get.