### PR TITLE
Restructure downloads page

### DIFF
--- a/public/content/en/welcome/install-d-locally.md
+++ b/public/content/en/welcome/install-d-locally.md
@@ -2,24 +2,33 @@
 
 On the D language's website [dlang.org](https://dlang.org) the most recent
 compiler version of the reference compiler **DMD** (Digital Mars D)
-can be downloaded and installed offline:
+can be [downloaded](http://dlang.org/download.html) and installed:
 
-* There is a Windows installer available - or a ZIP file which
-  contains the pre-compiled toolkit. Installing with
-  [chocolatey](https://chocolatey.org/packages/dmd)
-  is another option.
-* For Mac OS X there is a `.dmg` package. The most recent can also be installed
-  with `brew install dmd` using [Homebrew](http://brew.sh).
-* There are officially supported Linux packages for Fedora, OpenSuse and
-  Debian/Ubuntu. For the latter a regularly updated repository exists
-  at [d-apt.source-forge.net](http://d-apt.sourceforge.net).
-* On OSX, Linux, and FreeBSD a [script](https://dlang.org/install.sh) can
-  be used to easily install different compilers and dub to `$HOME/dlang`.
+### Windows
 
-  ```sh
-  curl -fsS https://dlang.org/install.sh | bash -s dmd
-  ```
-  
+* [Installer](http://downloads.dlang.org/releases/2.x/2.071.0/dmd-2.071.0.exe)
+* or: [Archive](http://downloads.dlang.org/releases/2.x/2.071.0/dmd.2.071.0.windows.7z)
+* using [chocolatey](https://chocolatey.org/packages/dmd): `choco install dmd`
+
+### Mac OS X
+
+* `.dmg` [package](http://downloads.dlang.org/releases/2.x/2.071.0/dmd.2.071.0.dmg)
+* or: [Archive](http://downloads.dlang.org/releases/2.x/2.071.0/dmd.2.071.0.osx.tar.xz)
+* using [Homebrew](http://brew.sh): `brew install dmd`
+
+### Linux / FreeBSD
+
+To quickly install dmd within your user directory, run: `curl -fsS https://dlang.org/install.sh | bash -s dmd`
+
+Packages for various distributions are provided:
+
+* [ArchLinux](https://wiki.archlinux.org/index.php/D_(programming_language))
+* [Debian/Ubuntu](http://d-apt.sourceforge.net).
+* [Fedora/CentOS](http://dlang.org/download.html#dmd)
+* [Gentoo](https://wiki.gentoo.org/wiki/Dlang)
+* [OpenSuse](http://dlang.org/download.html#dmd)
+
+### Other compilers
 
 Besides the DMD reference compiler which uses its own backend, there are
 two other compilers that can be fetched through the
@@ -31,4 +40,6 @@ two other compilers that can be fetched through the
 GDC and LDC aren't always at the most recent DMD frontend's versions, 
 but provide better optimization levels as well as support
 for other platforms like e.g. ARM.
+
+See the wiki for [more information](https://wiki.dlang.org/Compilers)
 


### PR DESCRIPTION
This is my first attempt (WIP again) to make a better installation page, because the current one has a pretty high dropout rate (see #234).

I am not happy with this restructure yet, because:

- hard-coded direct download links (maybe @CyberShadow or @MartinNowak can make a symbolic link for "stable")?
- no icons yet (@stonemaster maybe we can special blocks/macros that take only the to be translated headers as input, e.g. like `$(download_page, "Title", Description")`)
- Martin's install script can also be used for Mac OS too
- Link for Fedora and openSuse doesn't help the user much (I probably should add both i386 and x86_64 links)
- no autodetection of the OS yet (#246)

(that being said I still think it's an improvement to the status quo)