### PR TITLE
Prettify css

### DIFF
--- a/public/static/css/tour.css
+++ b/public/static/css/tour.css
@@ -8,13 +8,16 @@
 }
 
 #tour-content h1 {
-	font-weight: normal;
+	font-weight: 300;
+	padding-bottom: 10px;
 }
 #tour-content h2 {
-	font-weight: normal;
+	font-weight: 300;
+	padding-bottom: 5px;
 }
 #tour-content h3 {
-	font-weight: normal;
+	font-weight: 300;
+	padding-bottom: 5px;
 }
 
 #command-box {
@@ -41,8 +44,75 @@
 	margin-right: 0px;
 }
 
-pre.prettyprint {
+/* pre.prettyprint and div.prototype come from prettyprint.js */
+pre, pre.prettyprint, div.prototype
+{
+	background: white;
+	border-radius: 4px;
+	padding: 1ex;
+	margin: 1em 0 1em 0;
+	line-height: normal;
 	border: 1px solid #ccc;
-	margin-bottom: 0;
-	padding: 9.5px;
+	width: auto;
+}
+pre
+{
+	white-space: pre-wrap;		 /* css-3 */
+	white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+	white-space: -pre-wrap;		 /* Opera 4-6 */
+	white-space: -o-pre-wrap;	 /* Opera 7 */
+	word-wrap: break-word;		 /* Internet Explorer 5.5+ */
+}
+
+table
+{
+	border: solid #333;
+	border-width: 2px 0;
+	border-collapse: collapse;
+}
+
+table tr
+{
+	border: none;
+}
+
+table td, table th, table caption
+{
+	text-align: left;
+	vertical-align: top;
+	padding: 0.3em;
+}
+
+table td
+{
+	border: none;
+	border-bottom: 1px solid #E6E6E6;
+	text-align: justify;
+}
+
+table th
+{
+	border: none;
+	border-bottom: 1px solid #333;
+}
+
+table td:not(:last-child), table th:not(:last-child)
+{
+	padding-right: 1em;
+}
+
+/* dlang.org links */
+a, .question, .expand-toggle
+{
+	color: #B03931;
+	cursor: pointer;
+}
+
+a:hover, .question:hover, .expand-toggle:hover
+{
+	color: #742620;
+}
+
+pre, code, .tt, .d_inlinecode, td.param_id, .CodeMirror pre, .d_decl {
+	font-family: Consolas, "Bitstream Vera Sans Mono", "Andale Mono", Monaco, "DejaVu Sans Mono", "Lucida Console", monospace;
 }

--- a/views/base.dt
+++ b/views/base.dt
@@ -3,7 +3,7 @@ doctype html
 head
 	script(src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.9/angular.min.js")
 	link(rel="stylesheet", href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css", integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7",crossorigin="anonymous")
-	link(href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,700",rel="stylesheet",type="text/css")
+	link(href="https://fonts.googleapis.com/css?family=Roboto+Slab:300,400",rel="stylesheet",type="text/css")
 	script(src="//code.jquery.com/jquery-1.12.0.min.js")
 	script(src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js", integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS", crossorigin="anonymous")
 	link(rel="stylesheet", href="/static/css/common.css")


### PR DESCRIPTION
- import Robot Slab font via css, s.t. we are sure that the user has it
- use a thinner font weight for `h` elements
- add padding below `h` elements
- no background for `pre` elments
- borders for tables
- use a proper & nice monospace for `pre` elements
- use red links (like dlang.org)
- dlang.org code CSS classes

Comments
- while doing that, I realized that "prettify" doesn't support Dlang. Will fix this in a follow-up
- The CSS definitions are mostly taken from dlang.org
- I would prefer to split it into more CSS files, but then we would need to have a CSS bundling step

before:

![image](https://cloud.githubusercontent.com/assets/4370550/15990897/26961690-30a2-11e6-86b0-70780c13e946.png)

after:

![image](https://cloud.githubusercontent.com/assets/4370550/15990893/0387d3e6-30a2-11e6-8186-f71c46319f8f.png)


before:

![image](https://cloud.githubusercontent.com/assets/4370550/15990896/1e7c876e-30a2-11e6-8ae8-1a0ce02fbac7.png)

after:

![image](https://cloud.githubusercontent.com/assets/4370550/15990895/13428f56-30a2-11e6-991d-51f4a37ee73c.png)