### PR TITLE
use highlightjs

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -155,3 +155,12 @@ dlangTourApp.controller('DlangTourAppCtrl', [ '$scope', '$http', 'hotkeys', func
 		}
 	});
 }]);
+
+// use CodeMirror to highlight pre
+$(document).ready(function() {
+	$('code').each(function(i, block) {
+	    var val = block.textContent || "";
+		CodeMirror.runMode(val, "text/x-d", block);
+		block.className += "cm-s-elegant";
+	});
+});

--- a/public/static/lib/codemirror/addon/runmode.js
+++ b/public/static/lib/codemirror/addon/runmode.js
@@ -1,0 +1,72 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+"use strict";
+
+CodeMirror.runMode = function(string, modespec, callback, options) {
+  var mode = CodeMirror.getMode(CodeMirror.defaults, modespec);
+  var ie = /MSIE \d/.test(navigator.userAgent);
+  var ie_lt9 = ie && (document.documentMode == null || document.documentMode < 9);
+
+  if (callback.appendChild) {
+    var tabSize = (options && options.tabSize) || CodeMirror.defaults.tabSize;
+    var node = callback, col = 0;
+    node.innerHTML = "";
+    callback = function(text, style) {
+      if (text == "\n") {
+        // Emitting LF or CRLF on IE8 or earlier results in an incorrect display.
+        // Emitting a carriage return makes everything ok.
+        node.appendChild(document.createTextNode(ie_lt9 ? '\r' : text));
+        col = 0;
+        return;
+      }
+      var content = "";
+      // replace tabs
+      for (var pos = 0;;) {
+        var idx = text.indexOf("\t", pos);
+        if (idx == -1) {
+          content += text.slice(pos);
+          col += text.length - pos;
+          break;
+        } else {
+          col += idx - pos;
+          content += text.slice(pos, idx);
+          var size = tabSize - col % tabSize;
+          col += size;
+          for (var i = 0; i < size; ++i) content += " ";
+          pos = idx + 1;
+        }
+      }
+
+      if (style) {
+        var sp = node.appendChild(document.createElement("span"));
+        sp.className = "cm-" + style.replace(/ +/g, " cm-");
+        sp.appendChild(document.createTextNode(content));
+      } else {
+        node.appendChild(document.createTextNode(content));
+      }
+    };
+  }
+
+  var lines = CodeMirror.splitLines(string), state = (options && options.state) || CodeMirror.startState(mode);
+  for (var i = 0, e = lines.length; i < e; ++i) {
+    if (i) callback("\n");
+    var stream = new CodeMirror.StringStream(lines[i]);
+    if (!stream.string && mode.blankLine) mode.blankLine(state);
+    while (!stream.eol()) {
+      var style = mode.token(stream, state);
+      callback(stream.current(), style, i, stream.start, state);
+      stream.start = stream.pos;
+    }
+  }
+};
+
+});

--- a/views/tour.dt
+++ b/views/tour.dt
@@ -7,12 +7,12 @@ block head
 	script(src="/static/lib/codemirror/lib/codemirror.min.js")
 	script(src="/static/lib/codemirror/mode/d/d.min.js")
 	script(src="/static/lib/codemirror/addon/lint/lint.min.js")
+	script(src="/static/lib/codemirror/addon/runmode.js")
 	link(rel="stylesheet", href="/static/lib/codemirror/addon/lint/lint.min.css")
 	link(rel="stylesheet", href="/static/lib/codemirror/theme/elegant.css")
 	script(src="/static/lib/ui-codemirror.min.js")
 	script(src="/static/lib/hotkeys.min.js")
 	link(rel="stylesheet", href="/static/lib/hotkeys.min.css")
-	script(src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js")
 	link(rel="stylesheet", href="/static/css/tour.css")
 
 block content


### PR DESCRIPTION
follow-up to #253 

compare 

![image](https://cloud.githubusercontent.com/assets/4370550/15990971/2fd8aa90-30a4-11e6-8401-6035d9470db9.png)

with: 

![image](https://cloud.githubusercontent.com/assets/4370550/15990972/3941e0c4-30a4-11e6-9360-ff0e6bc72df0.png)

have a look at e.g. `immutable`

I realized that highlightjs doesn't recognize attributes correctly, e.g.

hightlight.js:
![image](https://cloud.githubusercontent.com/assets/4370550/15990977/6580b782-30a4-11e6-8ab3-a1b008215d92.png)

codemirror:

![image](https://cloud.githubusercontent.com/assets/4370550/15990979/7781fe82-30a4-11e6-9ea4-c0f178ef0302.png)


so probably that's only an intermediate step. Is there a way to use the CodeMirror highlighter for normal `pre` elements`