### PR TITLE
add references to ddili

### DIFF
--- a/public/content/en/basics/alias-strings.md
+++ b/public/content/en/basics/alias-strings.md
@@ -37,6 +37,11 @@ To create multi-line strings use the
 backticks `` ` "unescaped string"` ``
 or the r-prefix `r"string that "doesn't" need to be escaped"`.
 
+### In-depth
+
+- [Characters in _Programming in D_](http://ddili.org/ders/d.en/characters.html)
+- [Strings in _Programming in D_](http://ddili.org/ders/d.en/strings.html)
+
 ## {SourceCode}
 
 ```d

--- a/public/content/en/basics/arrays.md
+++ b/public/content/en/basics/arrays.md
@@ -57,6 +57,10 @@ that shifts the characters in the alphabet using a certain index.
 The to-be-encrypted text just contains characters in the range `a-z`
 which should make things easier.
 
+### In-depth
+
+- [Arrays in _Programming in D_](http://ddili.org/ders/d.en/arrays.html)
+
 ## {SourceCode:incomplete}
 
 ```d

--- a/public/content/en/basics/associative-arrays.md
+++ b/public/content/en/basics/associative-arrays.md
@@ -33,6 +33,7 @@ the special `.byKeys` and `.byValues` ranges.
 
 ### In-depth
 
+- [Associative arrays in _Programming in D_](http://ddili.org/ders/d.en/aa.html)
 - [Associative arrays spec](https://dlang.org/spec/hash-map.html)
 - [byPair](http://dlang.org/phobos/std_array.html#.byPair)
 

--- a/public/content/en/basics/basic-types.md
+++ b/public/content/en/basics/basic-types.md
@@ -54,7 +54,18 @@ Every type also has a `.stringof` property which yields its name as a string.
 
 ### In-depth
 
+#### Basic references
+
+- [Assignment](http://ddili.org/ders/d.en/assignment.html)
+- [Variables](http://ddili.org/ders/d.en/variables.html)
+- [Arithmetics](http://ddili.org/ders/d.en/arithmetic.html)
+- [Floating Point](http://ddili.org/ders/d.en/floating_point.html)
+- [Fundamental types in _Programming in D_](http://ddili.org/ders/d.en/types.html)
+
+#### Advanced references
+
 - [Overview of all basic data types in D](https://dlang.org/spec/type.html)
+- [`auto` and `typeof` in _Programming in D_](http://ddili.org/ders/d.en/auto_and_typeof.html)
 - [Type properties](https://dlang.org/spec/property.html)
 
 In D indexes have usually the alias type `size_t` as it is a type that

--- a/public/content/en/basics/classes.md
+++ b/public/content/en/basics/classes.md
@@ -40,7 +40,10 @@ use the special keyword `super`.
 
 ### In-depth
 
-- [Classes in D](https://dlang.org/spec/class.html)
+- [Classes in _Programming in D_](http://ddili.org/ders/d.en/class.html)
+- [Inheritance in _Programming in D_](http://ddili.org/ders/d.en/inheritance.html)
+- [Object class in  in _Programming in D_](http://ddili.org/ders/d.en/object.html)
+- [Classes in D spec](https://dlang.org/spec/class.html)
 
 ## {SourceCode}
 

--- a/public/content/en/basics/controlling-flow.md
+++ b/public/content/en/basics/controlling-flow.md
@@ -33,6 +33,15 @@ take a look at the source code example.
 
 ### In-depth
 
+#### Basic references
+
+- [Logical expressions in _Programming in D_](http://ddili.org/ders/d.en/logical_expressions.html)
+- [If statement in _Programming in D_](http://ddili.org/ders/d.en/if.html)
+- [Ternary expressions in _Programming in D_](http://ddili.org/ders/d.en/ternary.html)
+- [`switch` and `case` in _Programming in D_](http://ddili.org/ders/d.en/switch_case.html)
+
+#### Advanced references
+
 - [Expressions in detail](https://dlang.org/spec/expression.html)
 
 ## {SourceCode}

--- a/public/content/en/basics/foreach.md
+++ b/public/content/en/basics/foreach.md
@@ -31,6 +31,11 @@ large types. To prevent copying or enable *in-place
         e = 10; // overwrite value
     }
 
+### In-depth
+
+- [`foreach` in _Programming in D_](http://ddili.org/ders/d.en/foreach.html)
+- [`foreach` with Structs and Classes  _Programming in D_](http://ddili.org/ders/d.en/foreach_opapply.html)
+
 ## {SourceCode}
 
 ```d

--- a/public/content/en/basics/functions.md
+++ b/public/content/en/basics/functions.md
@@ -29,6 +29,11 @@ the parent's scope
         }
         ...
 
+### In-depth
+
+- [Functions in _Programming in D_](http://ddili.org/ders/d.en/functions.html)
+- [Function parameters in _Programming in D_](http://ddili.org/ders/d.en/function_parameters.html)
+
 ## {SourceCode}
 
 ```d

--- a/public/content/en/basics/interfaces.md
+++ b/public/content/en/basics/interfaces.md
@@ -18,7 +18,7 @@ function in a base class.
             ...
         }
     }
-    
+
     auto dog = new Animal;
     Animal animal = dog; // implicit cast to interface
     dog.makeNoise();
@@ -42,6 +42,7 @@ functions.
 
 ### In-depth
 
+- [Interfaces in _Programming in D_](http://ddili.org/ders/d.en/interface.html)
 - [Interfaces in D](https://dlang.org/spec/interface.html)
 
 ## {SourceCode}
@@ -55,7 +56,7 @@ interface Animal {
     void makeNoise();
 
     // NVI pattern. Uses makeNoise internally
-    // to customoze behaviour in inheriting
+    // to customoze behaviour inheriting
     // classes.
     final void multipleNoise(int n) {
         for(int i = 0; i < n; ++i) {

--- a/public/content/en/basics/loops.md
+++ b/public/content/en/basics/loops.md
@@ -47,6 +47,12 @@ If we are in a nested loop a label can be used to break any outer loop:
 
 The keyword `continue` starts with the next loop iteration.
 
+### In-depth
+
+- [`for` Loop in _Programming in D_](http://ddili.org/ders/d.en/for.html)
+- [`while` Loop in _Programming in D_](http://ddili.org/ders/d.en/while.html)
+- [`do while` Loop in _Programming in D_](http://ddili.org/ders/d.en/do_while.html)
+
 ## {SourceCode}
 
 ```d

--- a/public/content/en/basics/slices.md
+++ b/public/content/en/basics/slices.md
@@ -39,6 +39,7 @@ one past the slice's end and thus would generate a `RangeError`
 ### In-depth
 
 - [Introduction to Slices in D](http://dlang.org/d-array-article.html)
+- [Slices in _Programming in D_](http://ddili.org/ders/d.en/slices.html)
 
 ## {SourceCode}
 

--- a/public/content/en/basics/storage-classes.md
+++ b/public/content/en/basics/storage-classes.md
@@ -42,6 +42,13 @@ Both `immutable` and `const` are transitive which ensures that once
 
 ### In-depth
 
+#### Basic references
+
+- [Immutable in _Programming in D_](http://ddili.org/ders/d.en/const_and_immutable.html)
+- [Scopes in _Programming in D_](http://ddili.org/ders/d.en/name_space.html)
+
+#### Advanced references
+
 - [const(FAQ)](https://dlang.org/const-faq.html)
 - [Type qualifiers D](https://dlang.org/spec/const3.html)
 

--- a/public/content/en/basics/structs.md
+++ b/public/content/en/basics/structs.md
@@ -27,7 +27,7 @@ is defined through a `this(...)` member function:
             this.ageXHeight = cast(float)age * height;
         }
             ...
-    
+
     Person p(30, 180);
 
 A `struct` might contain any number of member functions. Those
@@ -41,7 +41,7 @@ module.
             ...
         private void privateStuff() {
             ...
-    
+
     p.doStuff(); // call method doStuff
     p.privateStuff(); // forbidden
 
@@ -75,6 +75,7 @@ polymorphic inheritance.
 
 ### In-depth
 
+- [Structs in _Programming in D_](http://ddili.org/ders/d.en/struct.html)
 - [In detail](https://dlang.org/spec/struct.html)
 
 ### Exercise

--- a/public/content/en/basics/templates.md
+++ b/public/content/en/basics/templates.md
@@ -45,6 +45,10 @@ types too.
 ### In-depth
 
 - [Tutorial to D Templates](https://github.com/PhilippeSigaud/D-templates-tutorial)
+- [Templates in _Programming in D_](http://ddili.org/ders/d.en/templates.html)
+
+#### Advanced
+
 - [D Templates spec](https://dlang.org/spec/template.html)
 - [Templates Revisited](http://dlang.org/templates-revisited.html):  Walter Bright writes about how D improves upon C++ templates.
 - [Variadic templates](http://dlang.org/variadic-function-templates.html): Articles about the D idiom of implementing variadic functions with variadic templates

--- a/public/content/en/gems/attributes.md
+++ b/public/content/en/gems/attributes.md
@@ -64,5 +64,6 @@ generators to adapt to that specific type.
 
 ### In-depth
 
+- [User Defined Attributes in _Programming in D_](http://ddili.org/ders/d.en/uda.html)
 - [Attributes in D](https://dlang.org/spec/attribute.html)
 

--- a/public/content/en/gems/contract-programming.md
+++ b/public/content/en/gems/contract-programming.md
@@ -52,7 +52,10 @@ state during its whole lifetime:
 
 ### In-depth
 
-- [Contract programming in D](https://dlang.org/spec/contracts.html)
+- [`assert` and `enforce` in _Programming in D_](http://ddili.org/ders/d.en/assert.html)
+- [Contract programming in _Programming in D_](http://ddili.org/ders/d.en/contracts.html)
+- [Contract Programming for Structs and Classes in _Programming in D_](http://ddili.org/ders/d.en/invariant.html)
+- [Contract programming in D spec](https://dlang.org/spec/contracts.html)
 
 ## {SourceCode:incomplete}
 

--- a/public/content/en/gems/opdispatch-opapply.md
+++ b/public/content/en/gems/opdispatch-opapply.md
@@ -63,6 +63,8 @@ must be stopped.
 
 ### In-depth
 
+- [Operator overloading in _Programming in D_](http://ddili.org/ders/d.en/operator_overloading.html)
+- [`opApply` in _Programming in D_](http://ddili.org/ders/d.en/foreach_opapply.html)
 - [Operator overloading in D](https://dlang.org/spec/operatoroverloading.html)
 
 ## {SourceCode}

--- a/public/content/en/gems/range-algorithms.md
+++ b/public/content/en/gems/range-algorithms.md
@@ -55,6 +55,12 @@ forever.
 
 ### The documentation is awaiting your visit!
 
+
+### In-depth
+
+- [Ranges in _Programming in D_](http://ddili.org/ders/d.en/ranges.html)
+- [More Ranges in _Programming in D_](http://ddili.org/ders/d.en/ranges_more.html)
+
 ## {SourceCode}
 
 ```d

--- a/public/content/en/gems/scope-guards.md
+++ b/public/content/en/gems/scope-guards.md
@@ -21,6 +21,10 @@ for special resources.
 
 Scope guards are called in the reverse order they are defined.
 
+### In-depth
+
+- [`scope` in _Programming in D_](http://ddili.org/ders/d.en/scope.html)
+
 ## {SourceCode}
 
 ```d

--- a/public/content/en/gems/template-meta-programming.md
+++ b/public/content/en/gems/template-meta-programming.md
@@ -66,11 +66,19 @@ the `[]` operator.
 
 ### In-depth
 
-- [Conditional compilation](https://dlang.org/spec/version.html)
+### Basics references
+
+- [Tutorial to D Templates](https://github.com/PhilippeSigaud/D-templates-tutorial)
+- [Conditional compilation](http://ddili.org/ders/d.en/cond_comp.html
 - [std.traits](https://dlang.org/phobos/std_traits.html)
+- [More templates  _Programming in D_](http://ddili.org/ders/d.en/templates_more.html)
+- [Mixins in  _Programming in D_](http://ddili.org/ders/d.en/mixin.html)
+
+### Advanced references
+
+- [Conditional compilation](https://dlang.org/spec/version.html)
 - [Traits](https://dlang.org/spec/traits.html)
 - [Mixin templates](https://dlang.org/spec/template-mixin.html)
-- [Tutorial to D Templates](https://github.com/PhilippeSigaud/D-templates-tutorial)
 - [D Templates spec](https://dlang.org/spec/template.html)
 
 ## {SourceCode}

--- a/public/content/en/gems/uniform-function-call-syntax-ufcs.md
+++ b/public/content/en/gems/uniform-function-call-syntax-ufcs.md
@@ -21,6 +21,10 @@ UFCS is especially important when dealing with
 together to perform complex operations, still allowing
 to write clear and manageable code.
 
+### In-depth
+
+- [UFCS in _Programming in D_](http://ddili.org/ders/d.en/ufcs.html)
+
 ## {SourceCode}
 
 ```d

--- a/public/content/en/gems/unittesting.md
+++ b/public/content/en/gems/unittesting.md
@@ -24,6 +24,7 @@ within classes or structs.
 
 ### In-depth
 
+- [Unit Testing in _Programming in D_](http://ddili.org/ders/d.en/unit_testing.html)
 - [Unittesting in D](https://dlang.org/spec/unittest.html)
 
 ## {SourceCode}

--- a/public/content/en/multithreading/fibers.md
+++ b/public/content/en/multithreading/fibers.md
@@ -40,6 +40,10 @@ non-blocking (or asynchronous) I/O operations
 in terms of fibers leading to a much cleaner
 code.
 
+### In-depth
+
+- [Fibers in _Programming in D_](http://ddili.org/ders/d.en/fibers.html)
+
 ## {SourceCode}
 
 ```d

--- a/public/content/en/multithreading/message-passing.md
+++ b/public/content/en/multithreading/message-passing.md
@@ -47,6 +47,11 @@ type:
 The `receive` family functions block until something
 has been sent to the thread's mailbox.
 
+
+### In-depth
+
+- [Messaging passing concurrency](http://ddili.org/ders/d.en/concurrency.html)
+
 ## {SourceCode}
 
 ```d

--- a/public/content/en/multithreading/std-parallelism.md
+++ b/public/content/en/multithreading/std-parallelism.md
@@ -71,6 +71,11 @@ on it. It will block until the reuslt is available.
 
     auto fileData = t.yieldForce;
 
+### In-depth
+
+- [Parallelism in _Programming in D_](http://ddili.org/ders/d.en/parallelism.html)
+- [`std.parallelism](http://dlang.org/phobos/std_parallelism.html)
+
 ## {SourceCode}
 
 ```d

--- a/public/content/en/multithreading/synchronization-sharing.md
+++ b/public/content/en/multithreading/synchronization-sharing.md
@@ -46,6 +46,10 @@ helper:
     shared int test = 5;
     test.atomicOp!"+="(4);
 
+### In-depth
+
+- [Data Sharing Concurrency in _Programming in D_](http://ddili.org/ders/d.en/concurrency_shared.html)
+
 ## {SourceCode}
 
 ```d


### PR DESCRIPTION
First step to tackle #193 (In-depth links to "Programming in D")

I noticed that quite many chapters don't have equivalent sections here, see the #193 for more details.
