### PR TITLE
Ignore markdown codeblocks - fixes #271

### DIFF
--- a/public/content/en/basics/alias-strings.md
+++ b/public/content/en/basics/alias-strings.md
@@ -9,7 +9,7 @@ new constructs in one line:
 The term `string` is defined by an `alias` expression which defines it
 as a slice of `immutable(char)`'s. That is, once a `string` has been constructed
 its content will never change again. And actually this is the second
-introduction: welcome UTF-8 `string`! 
+introduction: welcome UTF-8 `string`!
 
 Due to their immutablility `string`s can perfectly be shared among
 different threads. Being a slice parts can be taken out of it without
@@ -39,6 +39,7 @@ or the r-prefix `r"string that "doesn't" need to be escaped"`.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 import std.utf: count;
 import std.string: format;
@@ -70,4 +71,4 @@ void main() {
     // .. which of course looks the same!
     writeln("My dstring: ", dstr);
 }
-
+```

--- a/source/contentprovider.d
+++ b/source/contentprovider.d
@@ -125,6 +125,15 @@ class ContentProvider
 				enforce(content.sourceCode.empty, new Exception("%s: Double %s section in '%s'"
 							.format(filename, SourceCodeSectionTitle, content.title)));
 				content.sourceCode = section.bodyOnly;
+				// ignore markdown code blocks
+				if (content.sourceCode[0..3] == "```")
+				{
+                    // allow additional code language specifiers
+					auto startPos = content.sourceCode.countUntil("\n");
+					assert(content.sourceCode.length > 10, "source code file too small");
+	                // remove three first and last backticks
+					content.sourceCode = content.sourceCode[startPos + 1 .. $ - 4];
+				}
 				content.sourceCodeEnabled = section.title != SourceCodeDisabledSectionTitle;
 				content.sourceCodeIncomplete = section.title == SourceCodeIncompleteSectionTitle;
 				checkSourceCodeLineWidth(content.sourceCode, content.title);


### PR DESCRIPTION
Turns out there is an easy solution to #271 - as the sourceCode is already stripped, the first and last three character must be our three backticks. To make it a bit generic, this code will strip the entire first line, so all possible backticks combinations are allowed.

Maybe we write a simple RegEx or Parser that adds the markdown code blocks to our content files?