### PR TITLE
Add markdown codeblock

### DIFF
--- a/public/content/en/basics/arrays.md
+++ b/public/content/en/basics/arrays.md
@@ -59,6 +59,7 @@ which should make things easier.
 
 ## {SourceCode:incomplete}
 
+```d
 import std.stdio;
 
 /**
@@ -99,4 +100,4 @@ void main()
     assert(encrypted == [ 'm','u','b','s','e',
             'c','u','j','e','t' ]);
 }
-
+```

--- a/public/content/en/basics/associative-arrays.md
+++ b/public/content/en/basics/associative-arrays.md
@@ -38,6 +38,7 @@ the special `.byKeys` and `.byValues` ranges.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 /**
@@ -86,4 +87,4 @@ to efficient, *native* machine code.};
 
     writeln("Word counts: ", wordCount(text));
 }
-
+```

--- a/public/content/en/basics/basic-types.md
+++ b/public/content/en/basics/basic-types.md
@@ -66,6 +66,7 @@ with an `AssertionError` if it fails.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 void main()
@@ -96,4 +97,4 @@ void main()
     writeln(int.min, " ", int.max);
     writeln(int.stringof); // int
 }
-
+```

--- a/public/content/en/basics/classes.md
+++ b/public/content/en/basics/classes.md
@@ -44,6 +44,7 @@ use the special keyword `super`.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 // Fancy type which can be used for
@@ -118,4 +119,4 @@ void main()
             any.convertToString());
     }
 }
-
+```

--- a/public/content/en/basics/controlling-flow.md
+++ b/public/content/en/basics/controlling-flow.md
@@ -37,6 +37,7 @@ take a look at the source code example.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 void main()
@@ -56,4 +57,4 @@ void main()
             break;
     }
 }
-
+```

--- a/public/content/en/basics/delegates.md
+++ b/public/content/en/basics/delegates.md
@@ -56,7 +56,8 @@ of just one line.
 - [Delegate's specification](https://dlang.org/spec/function.html#closures)
 
 ## {SourceCode}
-import std.stdio;
+
+```dimport std.stdio;
 
 enum IntOps {
     add = 0,
@@ -107,4 +108,4 @@ void main()
     // real work for us!
     writeln("result: ", func(a, b));
 }
-
+```

--- a/public/content/en/basics/delegates.md
+++ b/public/content/en/basics/delegates.md
@@ -6,7 +6,7 @@ A function can also be a parameter to another function:
         // call passed function
         doer(5,5);
     }
-    
+
     doSomething(add); // use global function `add` here
                       // add must have 2 int parameters
 
@@ -57,7 +57,8 @@ of just one line.
 
 ## {SourceCode}
 
-```dimport std.stdio;
+```d
+import std.stdio;
 
 enum IntOps {
     add = 0,

--- a/public/content/en/basics/foreach.md
+++ b/public/content/en/basics/foreach.md
@@ -33,6 +33,7 @@ large types. To prevent copying or enable *in-place
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 void main() {
@@ -52,4 +53,4 @@ void main() {
             " = ", accumulator / row.length);
     }
 }
-
+```

--- a/public/content/en/basics/functions.md
+++ b/public/content/en/basics/functions.md
@@ -31,6 +31,7 @@ the parent's scope
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 import std.random;
 
@@ -81,6 +82,4 @@ void main()
 // NOTE:
 //   add(), sub(), mul() and div()
 //   are NOT visible outside of main!
-
-
-
+```

--- a/public/content/en/basics/imports-and-modules.md
+++ b/public/content/en/basics/imports-and-modules.md
@@ -19,10 +19,11 @@ It can also be used locally within functions.
 
 ## {SourceCode}
 
+```d
 void main()
 {
     import std.stdio;
     // or import std.stdio: writeln;
     writeln("Hello World!");
 }
-
+```

--- a/public/content/en/basics/interfaces.md
+++ b/public/content/en/basics/interfaces.md
@@ -46,6 +46,7 @@ functions.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 interface Animal {
@@ -83,4 +84,4 @@ void main() {
         animal.multipleNoise(5);
     }
 }
-
+```

--- a/public/content/en/basics/loops.md
+++ b/public/content/en/basics/loops.md
@@ -49,6 +49,7 @@ The keyword `continue` starts with the next loop iteration.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 /// Returns: average of array
@@ -81,5 +82,4 @@ void main()
         " = ", average(testers[i]));
     }
 }
-
-
+```

--- a/public/content/en/basics/memory.md
+++ b/public/content/en/basics/memory.md
@@ -37,6 +37,7 @@ world between SafeD and the underlying dirty low-level world.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 void safeFun() @safe
@@ -57,4 +58,4 @@ void main()
     safeFun();
     unsafeFun();
 }
-
+```

--- a/public/content/en/basics/ranges.md
+++ b/public/content/en/basics/ranges.md
@@ -36,6 +36,7 @@ Don't fool yourself into deleting the `assert`ions!
 
 ## {SourceCode:incomplete}
 
+```d
 import std.stdio;
 
 struct FibonacciRange
@@ -77,4 +78,4 @@ void main() {
     assert(the10Fibs ==
         [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]);
 }
-
+```

--- a/public/content/en/basics/slices.md
+++ b/public/content/en/basics/slices.md
@@ -42,6 +42,7 @@ one past the slice's end and thus would generate a `RangeError`
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 /**
@@ -68,4 +69,4 @@ void main()
         test, min);
     assert(min == 2);
 }
-
+```

--- a/public/content/en/basics/storage-classes.md
+++ b/public/content/en/basics/storage-classes.md
@@ -47,6 +47,7 @@ Both `immutable` and `const` are transitive which ensures that once
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 void main()
@@ -76,4 +77,4 @@ void main()
     // ERROR:
     // immutable int* imMutable = &mutable;
 }
-
+```

--- a/public/content/en/basics/structs.md
+++ b/public/content/en/basics/structs.md
@@ -91,6 +91,7 @@ the example application successfully run:
 
 ## {SourceCode:incomplete}
 
+```d
 struct Vector3 {
     double x;
     double y;
@@ -149,4 +150,4 @@ void main() {
     assert(vec2.toString() ==
         "x: 0.0 y: 20.0 z: 0.0");
 }
-
+```

--- a/public/content/en/basics/templates.md
+++ b/public/content/en/basics/templates.md
@@ -51,6 +51,7 @@ types too.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 /**
@@ -91,4 +92,4 @@ void main() {
     multipleNoise(dog, 5);
     multipleNoise(cat, 5);
 }
-
+```

--- a/public/content/en/gems/compile-time-function-evaluation-ctfe.md
+++ b/public/content/en/gems/compile-time-function-evaluation-ctfe.md
@@ -50,7 +50,8 @@ with every release of the compiler.
 
 ## {SourceCode}
 
-```dimport std.stdio: writeln;
+```d
+import std.stdio: writeln;
 
 /* Returns: square root of x using
  Newton's approximation scheme. */

--- a/public/content/en/gems/compile-time-function-evaluation-ctfe.md
+++ b/public/content/en/gems/compile-time-function-evaluation-ctfe.md
@@ -49,7 +49,8 @@ with every release of the compiler.
 - [Conditional compilation](https://dlang.org/spec/version.html)
 
 ## {SourceCode}
-import std.stdio: writeln;
+
+```dimport std.stdio: writeln;
 
 /* Returns: square root of x using
  Newton's approximation scheme. */
@@ -78,4 +79,4 @@ void main() {
     writeln("The sqrt of compile time 4 = ",
         cn);
 }
-
+```

--- a/public/content/en/gems/contract-programming.md
+++ b/public/content/en/gems/contract-programming.md
@@ -56,6 +56,7 @@ state during its whole lifetime:
 
 ## {SourceCode:incomplete}
 
+```d
 // Very simple Date type with a lot of
 // flaws. Hint: don't use it!
 struct Date {
@@ -105,4 +106,4 @@ void main() {
     // be propgated through e.g. exceptions.
     date.fromString("2016-13-7");
 }
-
+```

--- a/public/content/en/gems/documentation.md
+++ b/public/content/en/gems/documentation.md
@@ -32,6 +32,7 @@ sections.
 
 ## {SourceCode:incomplete}
 
+```d
 /**
   Calculates the square root of a number.
 
@@ -55,4 +56,4 @@ sections.
 */
 T sqrt(T)(T number) {
 }
-
+```

--- a/public/content/en/gems/functional-programming.md
+++ b/public/content/en/gems/functional-programming.md
@@ -40,6 +40,10 @@ by the compiler for templated functions and `auto` functions,
 where applicable (this is also true for `@safe`, `nothrow`,
 and `@nogc`).
 
+### In depth
+
+- [Functional DLang Garden](https://garden.dlang.io/)
+
 ## {SourceCode}
 
 ```d
@@ -85,8 +89,4 @@ void main()
         	.to!("msecs", double)
         	.writeln("took: miliseconds");
 }
-
-### In depth
-
-- [Functional DLang Garden](https://garden.dlang.io/)
 ```

--- a/public/content/en/gems/functional-programming.md
+++ b/public/content/en/gems/functional-programming.md
@@ -42,6 +42,7 @@ and `@nogc`).
 
 ## {SourceCode}
 
+```d
 import std.bigint;
 
 /**
@@ -88,4 +89,4 @@ void main()
 ### In depth
 
 - [Functional DLang Garden](https://garden.dlang.io/)
-
+```

--- a/public/content/en/gems/opdispatch-opapply.md
+++ b/public/content/en/gems/opdispatch-opapply.md
@@ -67,6 +67,7 @@ must be stopped.
 
 ## {SourceCode}
 
+```d
 // A Variant is something that might contain
 // any other type:
 // https://dlang.org/phobos/std_variant.html
@@ -105,4 +106,4 @@ void main() {
     // writeln("test.notthere = ",
     //   test.notthere);
 }
-
+```

--- a/public/content/en/gems/range-algorithms.md
+++ b/public/content/en/gems/range-algorithms.md
@@ -57,6 +57,7 @@ forever.
 
 ## {SourceCode}
 
+```d
 // Hey come on, just get the whole army!
 import std.algorithm: canFind, map,
   filter, sort, uniq, joiner, chunkBy, splitter;
@@ -111,4 +112,4 @@ to efficient, *native* machine code.};
       // pipe to stdout
       .writeln();
 }
-
+```

--- a/public/content/en/gems/scope-guards.md
+++ b/public/content/en/gems/scope-guards.md
@@ -23,6 +23,7 @@ Scope guards are called in the reverse order they are defined.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 void main()
@@ -41,4 +42,4 @@ void main()
 
     writeln("\t\t<h1>Hello World!</h1>");
 }
-
+```

--- a/public/content/en/gems/string-mixins.md
+++ b/public/content/en/gems/string-mixins.md
@@ -25,6 +25,7 @@ in the source code.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 auto calculate(string op, T)(T lhs, T rhs)
@@ -44,4 +45,4 @@ void main()
     writeln("8 * 8 = ", calculate!"*"(8,8));
     writeln("100 / 5 = ", calculate!"/"(100,5));
 }
-
+```

--- a/public/content/en/gems/subtyping.md
+++ b/public/content/en/gems/subtyping.md
@@ -27,6 +27,7 @@ accessing the `alias this` member.
 
 ## {SourceCode}
 
+```d
 import std.stdio: writeln;
 
 struct Vector3 {
@@ -53,4 +54,4 @@ void main()
     // extended!
     writeln("vec dot vec2 = ", vec.dot(vec2));
 }
-
+```

--- a/public/content/en/gems/template-meta-programming.md
+++ b/public/content/en/gems/template-meta-programming.md
@@ -75,6 +75,7 @@ the `[]` operator.
 
 ## {SourceCode}
 
+```d
 import std.traits: isFloatingPoint;
 import std.uni: toUpper;
 import std.string: format;
@@ -140,6 +141,4 @@ void main()
     writeln(vecInt.getX, ",",
       vecInt.getY, ",", vecInt.getZ);
 }
-
-
-
+```

--- a/public/content/en/gems/uniform-function-call-syntax-ufcs.md
+++ b/public/content/en/gems/uniform-function-call-syntax-ufcs.md
@@ -23,6 +23,7 @@ to write clear and manageable code.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 import std.algorithm;
 import std.range: iota;
@@ -40,4 +41,4 @@ void main()
     writeln(filter!(a => a % 2 == 0)
     			   (iota(1,10)));
 }
-
+```

--- a/public/content/en/gems/unittesting.md
+++ b/public/content/en/gems/unittesting.md
@@ -28,6 +28,7 @@ within classes or structs.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 struct Vector3 {
@@ -76,4 +77,4 @@ unittest {
     // returns the initial value of type.
     assert(vec.x == double.init);
 }
-
+```

--- a/public/content/en/multithreading/fibers.md
+++ b/public/content/en/multithreading/fibers.md
@@ -42,6 +42,7 @@ code.
 
 ## {SourceCode}
 
+```d
 import core.thread: Fiber;
 import std.stdio: write;
 import std.range: iota;
@@ -95,5 +96,4 @@ void main()
     // squareFiber could still be run because
     // it has finished yet!
 }
-
-
+```

--- a/public/content/en/multithreading/message-passing.md
+++ b/public/content/en/multithreading/message-passing.md
@@ -49,6 +49,7 @@ has been sent to the thread's mailbox.
 
 ## {SourceCode}
 
+```d
 import std.stdio: writeln;
 import std.concurrency;
 
@@ -125,4 +126,4 @@ void main()
         writeln("Received CancelAckMessage!");
     }
 }
-
+```

--- a/public/content/en/multithreading/std-parallelism.md
+++ b/public/content/en/multithreading/std-parallelism.md
@@ -73,6 +73,7 @@ on it. It will block until the reuslt is available.
 
 ## {SourceCode}
 
+```d
 import std.parallelism;
 import std.array: array;
 import std.stdio: writeln;
@@ -116,4 +117,4 @@ void main()
     // earlier.
     writeln(task.yieldForce);
 }
-
+```

--- a/public/content/en/multithreading/synchronization-sharing.md
+++ b/public/content/en/multithreading/synchronization-sharing.md
@@ -48,6 +48,7 @@ helper:
 
 ## {SourceCode}
 
+```d
 import std.concurrency;
 import core.atomic;
 
@@ -134,4 +135,4 @@ void main()
     auto stopped = receiveOnly!bool;
     assert(stopped);
 }
-
+```

--- a/public/content/en/multithreading/thread-local-storage.md
+++ b/public/content/en/multithreading/thread-local-storage.md
@@ -45,6 +45,7 @@ The ugly name is just a friendly reminder to use it rarely.
 
 ## {SourceCode}
 
+```d
 import std.concurrency;
 
 void worker(bool firstTime)
@@ -70,4 +71,4 @@ void main()
         spawn(&worker, true);
     }
 }
-
+```

--- a/public/content/en/vibed/basics-asynchronous-i-o.md
+++ b/public/content/en/vibed/basics-asynchronous-i-o.md
@@ -46,6 +46,7 @@ to implement a simple TCP based echo server.
 
 ## {SourceCode:disabled}
 
+```d
 import vibe.d;
 
 shared static this()
@@ -70,4 +71,4 @@ shared static this()
         // will close the client's connection.
     });
 }
-
+```

--- a/public/content/en/vibed/diet-templates.md
+++ b/public/content/en/vibed/diet-templates.md
@@ -54,6 +54,7 @@ are passed as template parameters to `render`.
 
 ## {SourceCode:disabled}
 
+```d
 doctype html
 html
   head
@@ -67,4 +68,4 @@ html
         b= num
     p Prints 8:
     p= min(10, 2*6, 8)
-
+```

--- a/public/content/en/vibed/json-rest-interface.md
+++ b/public/content/en/vibed/json-rest-interface.md
@@ -74,6 +74,7 @@ is shared between client and server.
 
 ## {SourceCode:disabled}
 
+```d
 import vibe.d;
 
 interface IRest
@@ -137,4 +138,4 @@ shared static this()
     settings.port = 8080;
     listenHTTP(settings, router);
 }
-
+```

--- a/public/content/en/vibed/web-server.md
+++ b/public/content/en/vibed/web-server.md
@@ -49,6 +49,7 @@ and just passes it if needed.
 
 ## {SourceCode:disabled}
 
+```d
 import vibe.d;
 
 class WebService
@@ -146,4 +147,4 @@ shared static this()
     settings.port = 8080;
     listenHTTP(settings, router);
 }
-
+```

--- a/public/content/en/welcome/welcome-to-d.md
+++ b/public/content/en/welcome/welcome-to-d.md
@@ -46,10 +46,11 @@ and we are glad about pull requests making this tour even better.
 
 ## {SourceCode}
 
+```d
 import std.stdio;
 
 // Let's get going!
 void main() {
     writeln("Hello World!");
 }
-
+```


### PR DESCRIPTION
Seems like automating does, isn't difficult

header:

```
perl -0777 -i -pe 's/(\{SourceCode.*\}\n)/\1\n```d/' **/*.md
```

footer:

```
for file in $(grep -Rl "SourceCode" .) ; do sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' -i $file; echo '```' >> $file; done
```

`alias-strings.md` was already part of the manual edit with #271 - I removed the trailing whitespace just for this file.