### PR TITLE
Use starting page from index.yml

### DIFF
--- a/public/content/en/index.yml
+++ b/public/content/en/index.yml
@@ -1,3 +1,5 @@
+title: Dlang Tour
+start: welcome/welcome-to-d
 ordering:
 - welcome
 - basics

--- a/source/webinterface.d
+++ b/source/webinterface.d
@@ -103,7 +103,8 @@ class WebInterface
 
 	void index(HTTPServerRequest req, HTTPServerResponse res)
 	{
-		getTour(req, res, "welcome", "welcome-to-d");
+		auto startPoint = contentProvider_.getMeta("en").start;
+		getTour(req, res, startPoint.chapter, startPoint.section);
 	}
 
 	/+


### PR DESCRIPTION
Fixes #225 partially and uses the start page from the `index.yml` file.

The title still isn't passed to the diet templates yet.