### PR TITLE
Changed presentation of tour home link

### DIFF
--- a/public/static/css/common.css
+++ b/public/static/css/common.css
@@ -30,7 +30,6 @@ body {
     padding: 0.6em 1em;
     position: relative;
     white-space: nowrap;
-    margin-right: 5em;
 }
 
 @media only screen and (max-width: 66em) {

--- a/views/base.dt
+++ b/views/base.dt
@@ -26,7 +26,7 @@ body(ng-app="DlangTourApp", class="ng-cloak")
 					a(href="https://dlang.org")
 						img(id="logo", alt="DLang Logo", src="/static/img/dlogo.svg")
 					a(href="#{req.rootDir}", id="title")
-						span The DLang Tour
+						span Tour Home
 				a(href="#", title="Menu", class="hamburger expand-toggle")
 					span Menu
 				#cssmenu


### PR DESCRIPTION
Before

<img width="511" alt="screen shot 2016-06-14 at 4 25 29 pm" src="https://cloud.githubusercontent.com/assets/680068/16058545/0218a826-324d-11e6-8859-3b5c1eb7877e.png">

After

<img width="463" alt="screen shot 2016-06-14 at 4 24 57 pm" src="https://cloud.githubusercontent.com/assets/680068/16058551/09980722-324d-11e6-82ef-edce804d0eb4.png">
