### PR TITLE
make pre font smaller

### DIFF
--- a/public/static/css/tour.css
+++ b/public/static/css/tour.css
@@ -54,6 +54,7 @@ pre, pre.prettyprint, div.prototype
 	line-height: normal;
 	border: 1px solid #ccc;
 	width: auto;
+	font-size: 14px;
 }
 pre
 {


### PR DESCRIPTION
- reduces the size of `pre` elements from 16px (content around it) to 14px (size of the CodeMirror on box)

before:

![image](https://cloud.githubusercontent.com/assets/4370550/16059793/ed1fe474-3284-11e6-935a-b359d2917c90.png)

after:

![image](https://cloud.githubusercontent.com/assets/4370550/16059847/2597eb80-3285-11e6-85c0-daaa4fb6e2ed.png)
