### PR TITLE
add some missing bootstrap css classes

### DIFF
--- a/public/static/css/common.css
+++ b/public/static/css/common.css
@@ -149,3 +149,28 @@ img {
     vertical-align: middle;
     border: 0;
 }
+code {
+    padding: 2px 4px;
+    font-size: 90%;
+    background-color: #f9f2f4;
+    border-radius: 4px;
+}
+pre code {
+	padding: 0;
+    font-size: 100%;
+    background-color: inherit;
+}
+.table {
+    width: 100%;
+    max-width: 100%;
+    margin-bottom: 20px;
+}
+.table>tbody>tr>td, .table>tbody>tr>th, .table>tfoot>tr>td, .table>tfoot>tr>th, .table>thead>tr>td, .table>thead>tr>th {
+    padding: 8px;
+    line-height: 1.42857143;
+    vertical-align: top;
+    border-top: 1px solid #ddd;
+}
+.table-hover>tbody>tr:hover {
+    background-color: #f5f5f5;
+}


### PR DESCRIPTION
adds some css classes from bootstrap back:

- tables (100% width, hover effects)
- `code` elements with background (manually modified)

Preview:

![image](https://cloud.githubusercontent.com/assets/4370550/16060860/2e4d5e22-328a-11e6-8ccb-2d1b0f7b2c3d.png)

![image](https://cloud.githubusercontent.com/assets/4370550/16060851/25355330-328a-11e6-9d89-67e2f4242a89.png)