### PR TITLE
code editor should adapt to source code - fix #283

### DIFF
--- a/public/static/css/tour.css
+++ b/public/static/css/tour.css
@@ -34,7 +34,7 @@
 	font-family: monospace;
 }
 
-.CodeMirror {
+body .CodeMirror {
 	height: auto;
 }
 


### PR DESCRIPTION
For me that was that's needed. It had nothing todo with Bootstrap, but with order of the css files - #275 as before it was:

```
<link rel="stylesheet" href="/static/lib/codemirror/lib/codemirror.min.css"/>
<link rel="stylesheet" href="/static/css/tour.css"/>
```