### PR TITLE
temporarily disable swiping - fixes #285

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -153,6 +153,8 @@ dlangTourApp.controller('DlangTourAppCtrl',
 		$window.open(url, '_blank');
 	}
 
+	/**
+	 * Swiping is temporarily disabled due to false positives
 	detectswipe(document.getElementById('tour-content'), function(el, direction, e) {
 		if (direction == "r") {
 			prevPage();
@@ -162,6 +164,7 @@ dlangTourApp.controller('DlangTourAppCtrl',
 			e.preventDefault();
 		}
 	});
+	*/
 }]);
 
 // use CodeMirror to highlight pre


### PR DESCRIPTION
Fix for #285 until we found the root cause. Most likely we need a full swiping javascript framework because it seems like those touch events aren't that simple :/