### PR TITLE
Use FontAwesome for menu hamburger icon

### DIFF
--- a/public/static/css/menu.css
+++ b/public/static/css/menu.css
@@ -229,9 +229,7 @@ the home page, intro pitch and your-code-here layed out vertically */
     }
     #top a.hamburger::after
     {
-        /*content: "\f0c9"; [> bars <]*/
-        /*font-family: FontAwesome;*/
-        font-family: 'Glyphicons Halflings';
-        content: "\e236";
+		content: "\f0c9";
+		font-family: FontAwesome;
     }
 }


### PR DESCRIPTION
Currently no menu hamburger is displayed on mobile devices.

Ok - this one is due to the missing bootstrap css, but we can easily use the similar FontAwesome icon.