### PR TITLE
Fix syntax highlighting

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -157,7 +157,7 @@ dlangTourApp.controller('DlangTourAppCtrl',
 
 // use CodeMirror to highlight pre
 function start() {
-	document.querySelectorAll('code').forEach(function(i, block) {
+	document.querySelectorAll('code').forEach(function(block) {
 	    var val = block.textContent || "";
 		CodeMirror.runMode(val, "text/x-d", block);
 		block.className += "cm-s-elegant";


### PR DESCRIPTION
It seems like that after the anti jQuery changes, this one went unnoticed.