### PR TITLE
show hide code button on the right side - fixes #279

### DIFF
--- a/views/tour.dt
+++ b/views/tour.dt
@@ -11,11 +11,12 @@ block content
 	.row(ng-controller="DlangTourAppCtrl as ctrl", ng-init="init('#{language}', '#{chapterId}', '#{section}', #{hasSourceCode}, '#{previousSection.link}', '#{nextSection.link}')")
 		div#tour-content(ng-show="showContent", ng-class="{'col-md-12': !showSourceCode, 'col-md-6 col-sm-12': showSourceCode}")
 			div(ng-hide="showProgramOutput")
-				.content-command-box(class="hidden-xs hidden-sm")
-					button.btn.btn-default.btn-sm(ng-click="showSourceCode = !showSourceCode", ng-class="{active: showSourceCode}")
-						code { code }
+				.content-command-box
 					button.btn.btn-default(ng-click="editOnGithub()")
-						span.fa.fa-edit(ng-show="showContent")
+						.fa.fa-edit
+					span.hidden-xs.hidden-sm
+						button.btn.btn-default.btn-sm(ng-click="showSourceCode = true", ng-hide="showSourceCode")
+							fa.fa-eye
 				|!= htmlContent
 			div(ng-show="showProgramOutput")
 				.content-command-box
@@ -28,6 +29,8 @@ block content
 				button.btn.btn-default(ng-click="showContent = !showContent")
 					i.fa.fa-expand(ng-show="showContent",aria-hidden="true")
 					i.fa.fa-compress(ng-hide="showContent",aria-hidden="true")
+				button.btn.btn-default.btn-sm.hidden-xs.hidden-sm(ng-click="showSourceCode = false")
+					fa.fa-eye-slash
 				- if (sourceCodeEnabled)
 					button.btn.btn-primary(ng-click="run()")
 						i.fa.fa-play(aria-hidden="true")


### PR DESCRIPTION
- shows the "hide code" button on the right side as "eye-slash" FontAwesome icon
- shows the edit button on mobile

desktop:

![image](https://cloud.githubusercontent.com/assets/4370550/16298895/d7563fe4-3937-11e6-8f09-477d8b3763c1.png)

(the buttons on the left side are a bit below the ones on the right side, but that issue is independent from this PR)

collapsed:

![image](https://cloud.githubusercontent.com/assets/4370550/16298909/e389db68-3937-11e6-955c-3e9bef546326.png)


mobile: 

![image](https://cloud.githubusercontent.com/assets/4370550/16298874/c87f64e6-3937-11e6-8b13-8874d1ed1642.png)

(button is now shown)