### PR TITLE
Show custom title

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -114,12 +114,13 @@ shared static this()
 	settings.bindAddresses = config.bindAddresses;
 	settings.useCompressionIfPossible = true;
 	settings.errorPageHandler = (HTTPServerRequest req, HTTPServerResponse res, HTTPServerErrorInfo error) {
+		auto title = "Page not found";
 		auto t = contentProvider.getTOC("en");
 		auto toc = &t;
 		auto googleAnalyticsId = config.googleAnalyticsId;
 		auto chapterId = "";
 		auto language = "en";
-		res.render!("error.dt", req, error, language, googleAnalyticsId, chapterId, toc)();
+		res.render!("error.dt", req, error, language, googleAnalyticsId, chapterId, toc, title)();
 		res.finalize();
 	};
 

--- a/source/webinterface.d
+++ b/source/webinterface.d
@@ -173,9 +173,10 @@ class WebInterface
 		auto previousSection = sec.linkCache.previousSection;
 		auto nextSection = sec.linkCache.nextSection;
 		auto googleAnalyticsId = googleAnalyticsId_;
+		auto title = sec.tourData.content.title ~ " - " ~ contentProvider_.getMeta(_language).title;
 		render!("tour.dt", htmlContent, language, section, sectionId,
 				sectionCount, chapterId, hasSourceCode, sourceCodeEnabled,
 				nextSection, previousSection, googleAnalyticsId,
-				toc)();
+				toc, title)();
 	}
 }

--- a/views/base.dt
+++ b/views/base.dt
@@ -6,7 +6,7 @@ head
 	link(rel="shortcut icon", href="/static/img/favicon.ico")
 	link(rel="stylesheet", type="text/css", href="/static/css/menu.css")
 	meta(name="viewport",content="width=device-width, initial-scale=1.0, minimum-scale=0.1, maximum-scale=10.0")
-	title The Dlang Tour
+	title #{title}
 	link(rel="stylesheet", href="/static/css/tour.css")
 	link(rel="stylesheet", href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css")
 	block head
@@ -50,5 +50,5 @@ body(ng-app="DlangTourApp", class="ng-cloak")
 		})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 		ga('create', '#{googleAnalyticsId}', 'auto');
 		ga('send', 'pageview');
-	
+
 	block js


### PR DESCRIPTION
Instead of "The Dlang Tour" shows the name of the section as page title.

e.g. "Functions - Dlang Tour"

(the name of the tour is already fetched from the language's main `index.yml`).