### PR TITLE
Fix typos in welcome/run-d-program-locally

### DIFF
--- a/public/content/en/welcome/run-d-program-locally.md
+++ b/public/content/en/welcome/run-d-program-locally.md
@@ -5,40 +5,40 @@ a package manager `dub`.
 
 ### DMD Compiler
 
-Given a D file `test.d` a binary is created using *DMD* with this command:
+The *DMD* compiler compiles D file(s) and creates a binary.
+On the command line *DMD* can be invoked with the filename:
 
-    dmd test.d
+    dmd hello.d
 
-Run `dmd --help` or browse the [online documentation](https://dlang.org/dmd-linux.html#switches)
-for an overview of available flags.
+There are many options that allow to modify the behavior of the *DMD* compiler.
+Browse the [online documentation](https://dlang.org/dmd.html#switches) or run `dmd --help` for an overview of available flags.
 
 ### On-the-fly compilation with `rdmd`
 
-The helper tool `rdmd` distributed with the DMD compiler
+The helper tool `rdmd`, distributed with the DMD compiler,
 will make sure to compile all dependencies and automatically runs
 the resulting application:
 
-    rdmd test.d
+    rdmd hello.d
 
 On UNIX systems the shebang line `#!/usr/bin/env rdmd` can be put
 on the first line of an executable D file to allow a script-like
 usage.
 
-Run `rdmd --help` or browse the [online documentation](https://dlang.org/rdmd.html)
-for an overview of available flags.
+Browse the [online documentation](https://dlang.org/rdmd.html) or run `rdmd --help` for for an overview of available flags.
 
 ### Package manager `dub`
 
 D's standard package manager is [dub](http://code.dlang.org). When dub is
-installed locally a new project `test` can be created using
-the command line
+installed locally, a new project `test` can be created using
+the command line:
 
-    dub init test
+    dub init hello
 
 Running `dub` inside this folder will fetch all dependencies, compile the
 application and run it.
 `dub build` will compile the project.
 
-Run `dub help` or browse the [online documentation](https://code.dlang.org/docs/commandline)
-for an overview of available commands and features.
+Browse the [online documentation](https://code.dlang.org/docs/commandline) or run `dub help` for an overview of available commands and features.
 
+All available dub packages can be browsed through dub's [web interface](https://code.dlang.org).


### PR DESCRIPTION
I put the link to the online docs upfront, because that's easier to reach if you are already in your browser. 

As `dmd`, `rdmd` and `dub` feature a similar text, which variant do you like most:

1a) Browse the [online documentation] or run `dub help` for an overview of available flags
1b) Browse the [online documentation] for an overview of available flags or run `dub help`.
2a) For an overview of available flags browse the [online documentation] or run `dub help`
2b) For an overview of available flags _either_ browse the [online documentation] or run `dub help`

(or suggest your own)