### PR TITLE
Remove mention of delegates in favor of named arguments

### DIFF
--- a/public/content/en/basics/functions.md
+++ b/public/content/en/basics/functions.md
@@ -8,6 +8,8 @@ D program. A function may return a value - or be declared with
         return lhs + rhs;
     }
 
+### `auto` return types
+
 If the return type is defined as `auto`, the D compiler infers the return
 type automatically. Hence multiple `return` statements must return values with
 compatible types.
@@ -23,6 +25,23 @@ compatible types.
             return 1.0;
     }
 
+### Default arguments
+
+Functions may optionally define default arguments.
+This avoids the tedious work to declare redundant
+overloads.
+
+    void plot(string msg, string color = "red") {
+        ...
+    }
+    plot("D rocks");
+    plot("D rocks", "blue");
+
+Once a default argument has been specified all following arguments
+must be default arguments too.
+
+### Local functions
+
 Functions might even be declared inside others functions where they may be
 used locally and aren't visible to the outside world.
 These function can even have access to objects local to
@@ -35,7 +54,7 @@ the parent's scope:
         }
         ...
 
-Such nested functions are called delegates and will be explained in more depth
+Such nested functions are called delegates and they will be explained in more depth
 [soon](basics/delegates).
 
 ### In-depth


### PR DESCRIPTION
Imho default arguments are a very nice feature of D and I think we never mention it.
I removed the reference to delegates as we don't use delegates in the beginning anyhows and explaining something only in parts isn't very helpful to the reader ;-)