### PR TITLE
change basic TOC - move delegates up between ranges and associative arrays

### DIFF
--- a/public/content/en/basics/index.yml
+++ b/public/content/en/basics/index.yml
@@ -13,9 +13,9 @@ ordering:
 - loops
 - foreach
 - ranges
+- delegates
 - associative-arrays
 - classes
 - interfaces
-- delegates
 - templates
 - further-reading


### PR DESCRIPTION
http://tour.dlang.io/tour/en/basics/associative-arrays uses anonymous lambda functions which aren't explained in the tour currently.
I will submit another PR that tries to explain that in the delegates section, but in any case we should move the delegates before associative arrays.