### PR TITLE
fix space in basics/alias-strings

### DIFF
--- a/public/content/en/basics/alias-strings.md
+++ b/public/content/en/basics/alias-strings.md
@@ -34,7 +34,7 @@ for UTF strings so in that case use the function `std.utf.count`.
 
 To create multi-line strings use the
 `string str = q{ ... }` syntax. For raw strings you can either use
-backticks `` ` "unescaped string"` ``
+backticks `` `"unescaped string"` ``
 or the r-prefix `r"string that "doesn't" need to be escaped"`.
 
 ### In-depth


### PR DESCRIPTION
a small step into a perfect world ;-)

Currently it looks like this:

![image](https://cloud.githubusercontent.com/assets/4370550/16316767/463529ca-3988-11e6-88d9-a8bbea5c33e1.png)