### PR TITLE
fix title in gems/ctfe

### DIFF
--- a/public/content/en/gems/compile-time-function-evaluation-ctfe.md
+++ b/public/content/en/gems/compile-time-function-evaluation-ctfe.md
@@ -1,8 +1,7 @@
-# Compile Time Function Evaluation - CTFE
+# Compile Time Function Evaluation (CTFE)
 
-*Compile Time Function Evaluation (CTFE)* is a mechanism
-which allows the compiler to execute functions
-at **compile time**. There is no special set of the D
+CTFE is a mechanism which allows the compiler to execute
+functions at **compile time**. There is no special set of the D
 language necessary to use this feature - whenever
 a function just depends on compile time known values
 the D compiler might decide to interpret


### PR DESCRIPTION
I don't mind how the title is formatted, but it should be consistent. The first formatting is UFCS, thus I changed it to this style:

![image](https://cloud.githubusercontent.com/assets/4370550/16331065/e85e2458-39ed-11e6-8a69-4c16a31d1479.png)

http://tour.dlang.io/tour/en/gems/uniform-function-call-syntax-ufcs