### PR TITLE
Implement HTML macros by using Mustache. Fixes #55.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome to the D community and thanks for your interest in contributing!
 
 ## Tour contents
 
-This directory contains the contents of the Dlang online tour.
+The directory `public/content` contains the contents of the Dlang online tour.
 
 ### Structure
 
@@ -76,3 +76,32 @@ are just ignored.
 * Pay attention to spelling
 
 See also the [Wikipedia guide on writing better articles](https://en.wikipedia.org/wiki/Wikipedia:Writing_better_articles).
+
+### Custom Mustache macros
+
+The dlang tour allows to define custom macros which allow to generate
+advanced HTML using the [Mustache](http://mustache.github.io/) template
+engine. Mustache is very simple and allows replacing a variable
+`{{foo}}` by some text. Note that the tour's markdown supports
+HTML directly so it is possible to define mustache variables
+using HTML.
+
+The file `public/content/template.yml` stores the definition
+of Mustache variables:
+
+	variables:
+		foo: bar
+		bar: foo
+	wrappers:
+		test: <h1>{{content}}</h1>
+
+
+There are two types of replacements implemented at the moment:
+
+- **Variales**: simple text replacements which are defined in the `variables`
+  section of `template.yml`. The tag `{{foo}}` will then be replace by _bar_.
+- **Wrappers**: are what mustache calls _functions_. They are used
+  as `{{#test}}hello{{/test}}` and the special tag `{{content}}`
+  is replaced by the content located between the start and end tag. So the above
+  would yield `<h1>hello</h1>`. Wrappers might contain other wrappers
+  and variables.

--- a/dub.sdl
+++ b/dub.sdl
@@ -6,6 +6,7 @@ homepage "http://tour.dlang.org"
 license "Boost"
 dependency "vibe-d" version="~>0.7.28"
 dependency "dyaml" version="~>0.5.2"
+dependency "mustache-d" version="~>0.1.1"
 
 copyFiles "config.yml"
 

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -2,12 +2,13 @@
 	"fileVersion": 1,
 	"versions": {
 		"dyaml": "0.5.3",
-		"tinyendian": "0.1.2",
 		"libasync": "0.7.9",
-		"memutils": "0.4.5",
-		"openssl": "1.1.4+1.0.1g",
-		"vibe-d": "0.7.28",
+		"libev": "5.0.0+4.04",
 		"libevent": "2.0.1+2.0.16",
-		"libev": "5.0.0+4.04"
+		"memutils": "0.4.5",
+		"mustache-d": "0.1.1",
+		"openssl": "1.1.4+1.0.1g",
+		"tinyendian": "0.1.2",
+		"vibe-d": "0.7.28"
 	}
 }

--- a/public/content/en/gems/template-meta-programming.md
+++ b/public/content/en/gems/template-meta-programming.md
@@ -26,7 +26,7 @@ a generic helper that evaluates conditions at compile time.
     }
 
 Braces are omitted if the condition is `true` - no new scope is created.
-`{{` and `}}` explicitely create a new block.
+`{ {` and `} }` explicitely create a new block.
 
 `static if` can be used anywhere in the code - in functions,
 at global scope or within type definitions.

--- a/public/content/en/welcome/welcome-to-d.md
+++ b/public/content/en/welcome/welcome-to-d.md
@@ -2,12 +2,12 @@
 
 Welcome to the online tour of the *D Programming language*.
 
-<img src="static/img/dman.png" class="img-left visible-xs" id="dman-front-mobile" />
+{{#dmanmobile}}
 
 This tour will give you an overview of this __powerful__ and __expressive__
 language which compiles directly to __efficient__, __native__ machine code.
 
-<div class="clear visible-xs"></div>
+{{/dmanmobile}}
 
 ### What is D?
 
@@ -15,7 +15,7 @@ D is the culmination of _decades of experience implementing compilers_
 for many diverse languages and has a large number of
 [unique features](http://dlang.org/overview.html):
 
-<img src="/static/img/dman.png" class="img-left hidden-xs" id="dman-front-desktop" />
+{{#dmandesktop}}
 
 - _high level_ constructs for great modeling power
 - _high performance_, compiled language
@@ -32,7 +32,7 @@ for many diverse languages and has a large number of
 
 ... and many more [features](http://dlang.org/overview.html).
 
-<div class="clear hidden-xs"></div>
+{{/dmandesktop}}
 
 ### About the tour
 

--- a/public/content/template.yml
+++ b/public/content/template.yml
@@ -1,0 +1,14 @@
+# Please see CONTRIBUTING.md for a description
+# of this file.
+
+#variables:
+#    test: test
+wrappers:
+    dmanmobile: |
+        <img src="static/img/dman.png" class="img-left visible-xs" id="dman-front-mobile" />
+        {{content}}
+        <div class="clear visible-xs"></div>
+    dmandesktop: |
+        <img src="/static/img/dman.png" class="img-left hidden-xs" id="dman-front-desktop" />
+        {{content}}
+        <div class="clear hidden-xs"></div>


### PR DESCRIPTION
Mustache is used to do text replacement using {{foo}} tags.
This has been extended to be able to define custom tags
that are defined in a `template.yml`. Besides normal text replacements
it's also possible to define more advanced mustache functions.