### PR TITLE
deleted unnecessary "in"

### DIFF
--- a/public/content/en/basics/classes.md
+++ b/public/content/en/basics/classes.md
@@ -43,7 +43,7 @@ use the special keyword `super`.
 
 - [Classes in _Programming in D_](http://ddili.org/ders/d.en/class.html)
 - [Inheritance in _Programming in D_](http://ddili.org/ders/d.en/inheritance.html)
-- [Object class in  in _Programming in D_](http://ddili.org/ders/d.en/object.html)
+- [Object class in _Programming in D_](http://ddili.org/ders/d.en/object.html)
 - [Classes in D spec](https://dlang.org/spec/class.html)
 
 ## {SourceCode}


### PR DESCRIPTION
`Object class in  in Programming in D` -> `Object class in Programming in D`