### PR TITLE
remove `you`

### DIFF
--- a/public/content/en/basics/storage-classes.md
+++ b/public/content/en/basics/storage-classes.md
@@ -3,7 +3,7 @@
 D is a statically typed language: once a variable has been declared,
 its type can't be changed from that point onwards. This allows
 the compiler to prevent bugs early and enforce restrictions
-at compile time.  Good type-safety gives you the support you need
+at compile time.  Good type-safety gives the support one needs
 to make large programs safer and more maintainable.
 
 ### `immutable`


### PR DESCRIPTION
yet another tiny thing I found - we try to write in a neutral tone, but nevertheless some `you` or `we`'s slip through. 