### PR TITLE
Only run Travis for the master branch & run sanity checks with DMD too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   # Compile & test with DMD
   - if [[ "${DC}" == "dmd" ]]; then  dub test --compiler=${DC};             fi
   - if [[ "${DC}" == "dmd" ]]; then  dub --compiler=${DC} -- --sanitycheck; fi
-  # Compiler to static binary with ldc
+  # Compile to static binary with ldc
   - if [[ "${DC}" == "ldc2" ]]; then  dub build -c static --compiler=${DC}; fi
   - if [[ "${DC}" == "ldc2" ]]; then docker build -t stonemaster/dlang-tour . ; fi
   - if [[ "${DC}" == "ldc2" ]]; then docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -ti stonemaster/dlang-tour --sanitycheck ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,19 @@ d:
 cache:
   - $HOME/.dub
 
+branches:
+  only:
+    - master
+
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libevent-dev
 
 script:
   # Compile & test with DMD
-  - if [[ "${DC}" == "dmd" ]]; then  dub test --compiler=${DC};            fi
-  # Compiler to static binary with gdc
+  - if [[ "${DC}" == "dmd" ]]; then  dub test --compiler=${DC};             fi
+  - if [[ "${DC}" == "dmd" ]]; then  dub --compiler=${DC} -- --sanitycheck; fi
+  # Compiler to static binary with ldc
   - if [[ "${DC}" == "ldc2" ]]; then  dub build -c static --compiler=${DC}; fi
   - if [[ "${DC}" == "ldc2" ]]; then docker build -t stonemaster/dlang-tour . ; fi
   - if [[ "${DC}" == "ldc2" ]]; then docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -ti stonemaster/dlang-tour --sanitycheck ; fi


### PR DESCRIPTION
A bit more of Travis magic applied:

1) restrict only to the `master` branch (currently it runs twice with all PRs made with branches on `dlang-tour`, e.g. hard to avoid when coming from the web UI)
2) Run sanity checks with for DMD too (just in case there are some recent compiler bugs)
3) Since quite some time we use ldc instead of gdc to create the static binary -> fixed the comment