### PR TITLE
Fix style: syntax-hightlighting + new lines

### DIFF
--- a/public/content/en/basics/exceptions.md
+++ b/public/content/en/basics/exceptions.md
@@ -9,7 +9,7 @@ A common case for exceptions is to validate potentially invalid user input.
 Once an exception is thrown, the stack will be unwound until the first matching exception
 handler is found.
 
-```
+```d
 try
 {
     readText("dummyFile");
@@ -23,7 +23,7 @@ catch (FileException e)
 You can also have multiple `catch` blocks and a `finally` block that is executed
 regardless of whether an error occurred. Exceptions are thrown with `throw`.
 
-```
+```d
 try
 {
     throw new StringException("You shall not pass.");
@@ -49,7 +49,7 @@ pattern.
 
 One can easily inherit from `Exception` and create custom exceptions:
 
-```
+```d
 class UserNotFoundException : Exception
 {
     this(string msg, string file = __FILE__, size_t line = __LINE__) {
@@ -65,7 +65,7 @@ The D compiler can ensure that a function can't cause catastrophic side-effects.
 Such functions can be annotated with the `nothrow` keyword. The D compiler
 statically forbids throwing exceptions in `nothrow` functions.
 
-```
+```d
 bool lessThan(int a, int b) nothrow
 {
     writeln("unsafe world"); // output can throw exceptions, thus this is forbidden
@@ -83,7 +83,7 @@ are removed when compiled in release mode. For convenience `std.exception` provi
 `enforce` that can be used like `assert`, but throws `Exceptions`
 instead of an `AssertError`.
 
-```
+```d
 import std.exception: enforce;
 float magic = 1_000_000_000;
 enforce(magic + 42 - magic == 42, "Floating-point math is fun");
@@ -95,7 +95,7 @@ enforce!StringException('a' != 'A', "Case-sensitive algorithm");
 However there's more in `std.exception`. For example when the error might not be
 fatal, one can opt-in to `collect` it:
 
-```
+```d
 import std.exception: collectException;
 auto e = collectException(aDangerousOperation());
 if (e)
@@ -113,6 +113,7 @@ To test whether an exception is thrown in tests, use `assertThrown`.
 
 ## {SourceCode}
 
+```
 import std.file;
 import std.stdio;
 
@@ -133,3 +134,4 @@ void main()
 		// writeln(e);
     }
 }
+```

--- a/public/content/en/basics/exceptions.md
+++ b/public/content/en/basics/exceptions.md
@@ -113,7 +113,7 @@ To test whether an exception is thrown in tests, use `assertThrown`.
 
 ## {SourceCode}
 
-```
+```d
 import std.file;
 import std.stdio;
 

--- a/public/content/en/gems/bit-manipulation.md
+++ b/public/content/en/gems/bit-manipulation.md
@@ -20,7 +20,7 @@ A common example for bit manipulation is to read the value of a bit.
 D provides `core.bitop.bt` for most common tasks, however to get used to bit
 manipulation, let's start with a verbose implementation of testing a bit:
 
-```
+```d
 enum posA = 1;
 enum maskA = (1 << posA);
 bool getFieldA()
@@ -33,7 +33,7 @@ A generalization is to test for blocks that are longer than 1. Hence
 a special read mask with the length of the block is needed
 and the data block is shifted accordingly before applying the mask:
 
-```
+```d
 enum posA = 1;
 enum lenA = 3;
 enum maskA = (1 << lenA) - 1; // ...0111
@@ -46,7 +46,7 @@ uint getFieldA()
 Setting such a block can equivalently be defined by negating the mask and thus
 only allowing writes within the specified block:
 
-```
+```d
 void setFieldA(bool b);
 {
     return (_data & ~maskAWrite) | ((b << aPos) & maskAWrite);
@@ -80,6 +80,7 @@ to start with fields of high alignments.
 
 ## {SourceCode}
 
+```d
 struct BitVector
 {
     import std.bitmanip : bitfields;
@@ -119,3 +120,4 @@ void main()
 	// 4 bytes are used for each field
 	writeln(BadVector.sizeof);
 }
+```

--- a/public/content/en/gems/traits.md
+++ b/public/content/en/gems/traits.md
@@ -9,7 +9,7 @@ heavy optimizations can be achieved.
 Traits allow to specify explicitly what input is accepted.
 For example `splitIntoWords` can operate on any arbitrary string type:
 
-```
+```d
 S[] splitIntoWord(S)(S input)
 if (isSomeString!S)
 ```
@@ -17,7 +17,7 @@ if (isSomeString!S)
 This applies to template parameters as well and `myWrapper` can ensure that the
 passed-in symbol is a callable function:
 
-```
+```d
 void myWrapper(alias f)
 if (isCallable!f)
 ```
@@ -26,7 +26,7 @@ As a simple example, [`commonPrefix`](https://dlang.org/phobos/std_algorithm_sea
 from `std.algorithm.searching`, which returns the common prefix of two ranges,
 will be analyzed:
 
-```
+```d
 auto commonPrefix(alias pred = "a == b", R1, R2)(R1 r1, R2 r2)
 if (isForwardRange!R1
     isInputRange!R2 &&
@@ -53,7 +53,7 @@ of a stream or list before walking through it.
 Hence a simple implementation of the `std.range` method `walkLength`
 which generalizes for any iterable type would be:
 
-```
+```d
 static if (hasMember!(r, "length"))
     return r.length; // O(1)
 else
@@ -73,7 +73,7 @@ between positions and thus speed-up the algorithm.
 D's [traits](https://dlang.org/spec/traits.html) except for some like
 `compiles` that can't be wrapped as it would lead to an immediate compile error:
 
-```
+```d
 __traits(compiles, obvious error - $%42); // false
 ```
 
@@ -81,7 +81,7 @@ __traits(compiles, obvious error - $%42); // false
 
 Additionally for debugging purposes D provides a couple of special keywords:
 
-```
+```d
 void test(string file = __FILE__, size_t line = __LINE__, string mod = __MODULE__,
           string func = __FUNCTION__, string pretty = __PRETTY_FUNCTION__)
 {
@@ -92,7 +92,7 @@ void test(string file = __FILE__, size_t line = __LINE__, string mod = __MODULE_
 
 With D's CLI evaluation one doesn't even need `time` - CTFE can be used!
 
-```
+```d
 rdmd --force --eval='pragma(msg, __TIMESTAMP__);'
 ```
 
@@ -105,6 +105,7 @@ rdmd --force --eval='pragma(msg, __TIMESTAMP__);'
 
 ## {SourceCode}
 
+```d
 import std.functional: binaryFun;
 import std.range;
 import std.stdio;
@@ -167,3 +168,4 @@ void main()
     writeln(commonPrefix("hello, world"d,
                          "hello, there"d));
 }
+```

--- a/public/content/en/vibed/deploy-on-heroku.md
+++ b/public/content/en/vibed/deploy-on-heroku.md
@@ -174,7 +174,6 @@ providing a single channel for all of the events.
 $ heroku logs --tail
 ```
 
-
 ## More informations
 
 After deploying the app to Heroku you can make it more awesome by using add-ons. For example :


### PR DESCRIPTION
The tutorials I wrote a while ago where written before some major changes to the Tour were made and as they were pending a bit in the queue, so they didn't enjoy my automatic regex through the content.

One nice change we made to the Markdown parser is that it accepts backticks inline and for the source code listings. The advantage is that the Markdown will be rendered nicely with D syntax highlighting on the Github content and preview pages).

While looking through the other files, I noticed a double-empty line & so I quickly added it here to keep the noise down a bit.