### PR TITLE
Fix: NodeList doesn't expose forEach on FF

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -157,7 +157,7 @@ dlangTourApp.controller('DlangTourAppCtrl',
 
 // use CodeMirror to highlight pre
 function start() {
-	document.querySelectorAll('code').forEach(function(block) {
+	[].forEach.call(document.querySelectorAll('code'), function(block) {
 	    var val = block.textContent || "";
 		CodeMirror.runMode(val, "text/x-d", block);
 		block.className += "cm-s-elegant";


### PR DESCRIPTION
I noticed this while looking at the output on the FF console.
Well I thought something like this wouldn't happen in a modern FF, but ...