### PR TITLE
Remove keyboard shortcut on mobile - fixes #197

### DIFF
--- a/views/tour.dt
+++ b/views/tour.dt
@@ -50,7 +50,7 @@ block content
 			a(href="#{nextSection.link}", ng-show="'' != '#{nextSection.link}'")
 				span.h4 #{nextSection.title}
 				| >
-		.container
+		.container.hidden-xs.hidden-sm
 			p.text-muted.text-center
 				kbd ?
 				| Keyboard shortcuts


### PR DESCRIPTION
Rather trivial.

before:

![image](https://cloud.githubusercontent.com/assets/4370550/17953252/32af3ff6-6a72-11e6-93b0-cb05fd74c13f.png)


after:

![image](https://cloud.githubusercontent.com/assets/4370550/17953248/211e542a-6a72-11e6-900f-a32692915605.png)
