### PR TITLE
Add japanese translation submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "public/content/sv"]
 	path = public/content/sv
 	url = https://github.com/dlang-tour/swedish
+[submodule "public/content/ja"]
+	path = public/content/ja
+	url = https://github.com/dlang-tour/japanese


### PR DESCRIPTION
FYI @kotet @alphaKAI @simdnyan - with this PR the japanese submodule will be linked to the main tour :)

- two-letter [ISO 639-1](https://www.loc.gov/standards/iso639-2/php/code_list.php) shortform is used (as for the other languages)

In case someone is interested, it's simply:

```
git submodule add https://github.com/dlang-tour/japanese public/content/ja
```

(also documented in [the wiki](https://github.com/stonemaster/dlang-tour/wiki/Adding-a-new-language-repo))