### PR TITLE
Allow the tour to be used from the a language directory - fixes #461

### DIFF
--- a/source/webinterface.d
+++ b/source/webinterface.d
@@ -21,13 +21,16 @@ class WebInterface
 		LinkCache[string][string][string] sectionLinkCache_;
 			///< language, chapter and section indexing
 		string googleAnalyticsId_; ///< ID for google analytics
+		string defaultLang = "en";
 	}
 
 	this(ContentProvider contentProvider,
-		string googleAnalyticsId)
+		string googleAnalyticsId, string defaultLang)
 	{
 		this.contentProvider_ = contentProvider;
 		this.googleAnalyticsId_ = googleAnalyticsId;
+		this.defaultLang = defaultLang;
+
 		// Fetch all table-of-contents for all supported
 		// languages (just 'en' for now) and generate
 		// the previous/next link cache for each tour page.
@@ -104,7 +107,7 @@ class WebInterface
 
 	void index(HTTPServerRequest req, HTTPServerResponse res)
 	{
-		getStart(req, res, "en");
+		getStart(req, res, defaultLang);
 	}
 
 	@path("/tour/:language")


### PR DESCRIPTION
This allows the following:

```
dlang-tour -l .
// or for the more verbose people
dlang-tour --lang-dir .
```

and more importantly:

```
dlang-tour -l . --sanity-check
```

- If the `-l` option is used, the prebundled languages will be ignored
   - testing German with a the bundled German doesn't make sense)
   - sanity-checking bundled content doesn't make sense either 
- It sets the language as default language, s.t. the tour automatically opens in the to be tested language (here for German):

![image](https://cloud.githubusercontent.com/assets/4370550/17975490/3485ed84-6aea-11e6-884e-568594cc1b96.png)

This is based on #469.

@stonemaster Could you release a 1.0.2 version after this has been merged because this allows with #469 the tour to be run offline and with this PR to be used conveniently for translators.