### PR TITLE
[trivial] Enable Markdown table syntax

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,6 +1,6 @@
 name "dlang-tour"
 description "The Dlang Tour"
-copyright "Copyright © 2015, André Stein"
+copyright "Copyright © 2016, André Stein"
 authors "André Stein" "Sebastian Wilzbach"
 homepage "http://tour.dlang.org"
 license "Boost"

--- a/source/contentprovider.d
+++ b/source/contentprovider.d
@@ -242,7 +242,7 @@ class ContentProvider
 	{
 		auto processed = expandMacros(content, mustacheContext_);
 		auto settings = new MarkdownSettings;
-		settings.flags = MarkdownFlags.backtickCodeBlocks | MarkdownFlags.vanillaMarkdown;
+		settings.flags = MarkdownFlags.backtickCodeBlocks | MarkdownFlags.vanillaMarkdown | MarkdownFlags.tables;
 		settings.urlFilter = (string link, bool) {
 			import std.algorithm.searching : startsWith;
 			if (link.startsWith("http") || link.startsWith("https") || link.startsWith("irc") || link[0] != '/')


### PR DESCRIPTION
Simply enables the use of the markdown table syntax with the Vibe.d parser

Introduced in https://github.com/rejectedsoftware/vibe.d/commit/5480a5c276ad9a49ffbfa4a1c94cb0749b0f4f9b
