### PR TITLE
Fix markdown link parser

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -90,6 +90,7 @@ private void doSanityCheck(ContentProvider contentProvider, IExecProvider execPr
 	}
 }
 
+version(unittest) {} else
 shared static this()
 {
 	import std.file : thisExePath;

--- a/source/contentprovider.d
+++ b/source/contentprovider.d
@@ -245,7 +245,7 @@ class ContentProvider
 		settings.flags = MarkdownFlags.backtickCodeBlocks | MarkdownFlags.vanillaMarkdown | MarkdownFlags.tables;
 		settings.urlFilter = (string link, bool) {
 			import std.algorithm.searching : startsWith;
-			if (link.startsWith("http") || link.startsWith("https") || link.startsWith("irc") || link[0] != '/')
+			if (link.startsWith("http", "https", "irc", "/"))
 				return link;
 			else
 			{
@@ -254,6 +254,18 @@ class ContentProvider
 			}
 		};
 		return filterMarkdown(processed, settings);
+	}
+
+	unittest
+	{
+		import std.stdio;
+		import std.algorithm;
+		string contentDir = "public/content";
+		auto cp = new ContentProvider(contentDir);
+		cp.addLanguage(contentDir.buildPath("en"));
+
+		assert(cp.processMarkdown("[foo](welcome/welcome-to-d)", "en") == "<p><a href=\"/tour/en/welcome/welcome-to-d\">foo</a>\n</p>\n");
+		assert(cp.processMarkdown("[foo](http://dlang.org)", "en") == "<p><a href=\"http://dlang.org\">foo</a>\n</p>\n");
 	}
 
 	/++


### PR DESCRIPTION
I saw that our Markdown link parser doesn't check the links between gems (they start without a `/`). 

This depends on #470 and the already merged PR at the English repo: https://github.com/dlang-tour/english/pull/64
