### PR TITLE
Exit if no config file has been found

### DIFF
--- a/source/contentprovider.d
+++ b/source/contentprovider.d
@@ -136,7 +136,10 @@ class ContentProvider
 
 		auto configFile = langDirectory.buildPath("index.yml");
 		if (!configFile.exists)
+		{
 			logInfo("Missing index.yml for %s", langDirectory);
+			return;
+		}
 
 		auto language = langDirectory.baseName;
 		auto root = Loader(configFile).load();


### PR DESCRIPTION
It turns out that we changed the behavior for the submodule slightly, see e.g. https://github.com/dlang-tour/russian/pull/12

The problem is that don't checkout the submodules on purpose (to avoid the overhead of doing the sanitycheck for them as well). While the new `--lang-dir` is a replacement for this behavior, this simple fix will fix the Travis builds without the need to update the `.travis.yml`. 