### PR TITLE
Update dub.json

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -5,7 +5,7 @@ authors "André Stein" "Sebastian Wilzbach"
 homepage "http://tour.dlang.org"
 license "Boost"
 dependency "vibe-d" version="~>0.7.31-rc.3"
-dependency "dyaml-dlang-tour" version="~>0.5.5"
+dependency "dyaml" version="~>0.6.1"
 dependency "mustache-d-dlang-tour" version="~>0.1.2"
 
 copyFiles "config.yml"


### PR DESCRIPTION
Use the official version of dyaml now that the repo was migrated to https://github.com/dlang-community/D-YAML.