### PR TITLE
Update mustache-d to upstream repo

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -4,7 +4,7 @@ copyright "Copyright © 2016, André Stein"
 authors "André Stein" "Sebastian Wilzbach"
 homepage "http://tour.dlang.org"
 license "Boost"
-dependency "vibe-d" version="~>0.7.31-rc.3"
+dependency "vibe-d" version="~>0.7.31"
 dependency "dyaml" version="~>0.6.1"
 dependency "mustache-d" version="~>0.1.3"
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -6,7 +6,7 @@ homepage "http://tour.dlang.org"
 license "Boost"
 dependency "vibe-d" version="~>0.7.31-rc.3"
 dependency "dyaml" version="~>0.6.1"
-dependency "mustache-d-dlang-tour" version="~>0.1.2"
+dependency "mustache-d" version="~>0.1.3"
 
 copyFiles "config.yml"
 

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,14 +1,15 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"diet-ng": "1.1.0",
-		"dyaml-dlang-tour": "0.5.5",
+		"diet-ng": "1.2.1",
+		"dyaml": "0.6.1",
 		"libasync": "0.8.3",
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "0.4.9",
+		"mustache-d": "0.1.3",
 		"mustache-d-dlang-tour": "0.1.2",
 		"openssl": "1.1.5+1.0.1g",
 		"tinyendian": "0.1.2",
-		"vibe-d": "0.7.31-rc.3"
+		"vibe-d": "0.7.31"
 	}
 }


### PR DESCRIPTION
No need to maintain our own fork anymore and [repo](https://github.com/repeatedly/mustache-d) seems more active lately.