### PR TITLE
Fix #478 - don't display toggle button if there's no source code

### DIFF
--- a/source/webinterface.d
+++ b/source/webinterface.d
@@ -169,7 +169,7 @@ class WebInterface
 		auto htmlContent = sec.tourData.content.html;
 		auto chapterId = _chapter;
 		auto hasSourceCode = !sec.tourData.content.sourceCode.empty;
-		auto sourceCodeEnabled = sec.tourData.content.sourceCodeEnabled;
+		auto sourceCodeEnabled = hasSourceCode && sec.tourData.content.sourceCodeEnabled;
 		auto section = _section;
 		auto sectionId =  sec.tourData.content._id;
 		auto sectionCount = sec.tourData.sectionCount;

--- a/views/tour.dt
+++ b/views/tour.dt
@@ -14,9 +14,10 @@ block content
 				.content-command-box
 					button.btn.btn-default(ng-click="editOnGithub()")
 						.fa.fa-edit
-					span.hidden-xs.hidden-sm
-						button.btn.btn-default.btn-sm(ng-click="showSourceCode = true", ng-hide="showSourceCode")
-							.fa.fa-eye
+					- if (sourceCodeEnabled)
+						span.hidden-xs.hidden-sm
+							button.btn.btn-default.btn-sm(ng-click="showSourceCode = true", ng-hide="showSourceCode")
+								.fa.fa-eye
 				|!= htmlContent
 			div(ng-show="showProgramOutput")
 				.content-command-box


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/4370550/26309685/385d4158-3efe-11e7-8c8d-527a7efe02ca.png)


After:

![image](https://cloud.githubusercontent.com/assets/4370550/26309675/2aedefc2-3efe-11e7-8759-eedc3ef7e8f7.png)