### PR TITLE
Fix sanity checker

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -99,7 +99,8 @@ private void doSanityCheck(ContentProvider contentProvider, IExecProvider execPr
 					section.language, section.title);
 
 			IExecProvider.RunInput input = {
-				source: section.sourceCode
+				source: section.sourceCode,
+				color: false,
 			};
 			auto result = execProvider.compileAndExecute(input);
 			enforce(result.success,

--- a/source/exec/stupidlocal.d
+++ b/source/exec/stupidlocal.d
@@ -111,19 +111,24 @@ class StupidLocal: IExecProvider
 			{
 				args = [dCompiler];
 				args ~= input.args.split(" ");
-				args ~= "-color=" ~ (input.color ? "on " : "off ");
+				args ~= "-color=" ~ (input.color ? "on" : "off");
 				args ~= "-run";
 				args ~= tmpfile.name;
 
-				// DMD requires a TTY for colored output
-				auto env = [
-					"TERM": "dtour"
-				];
-				auto fakeTty = `
-faketty () {	 script -qfc "$(printf "%q " "$@")" /dev/null ; }
-faketty ` ~ 	args.join(" ") ~  ` | cat | sed 's/\r$//'`;
+				if (input.color)
+				{
+					// DMD requires a TTY for colored output
+					auto env = [
+						"TERM": "dtour"
+					];
+					auto fakeTty = `
+faketty () {		 script -qfc "$(printf "%q " "$@")" /dev/null ; }
+faketty ` ~ 		args.join(" ") ~  ` | cat | sed 's/\r$//'`;
 
-				res = fakeTty.executeShell(env);
+					res = fakeTty.executeShell(env);
+				} else {
+					res = execute(args);
+				}
 			}
 			result.success = res.status == 0;
 			result.output = res.output;


### PR DESCRIPTION
Somehow the `script` hack to get the color support working doesn't report the exit codes correctly.
I might have a look into this later, but for now `canFind("Error:")` should work too.